### PR TITLE
(PE-2866) Prepare trapperkeeper-webserver-jetty9 for 0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.3-SNAPSHOT
+## 0.3.3
  * Fix bug where even if no http `port` was specified in the webserver config,
    the Jetty webserver was still opening an http binding on port 8080.  An
    http port binding will now be opened only if a `port` is specified in the

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -11,6 +11,6 @@ echo "Tests passed!"
 lein release
 echo "Release plugin successful, pushing changes to git"
 
-git push origin --tags `git rev-parse --abbrev-ref HEAD`
+git push origin --tags HEAD:master
 
 echo "git push successful."

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def tk-version "0.3.2")
-(def ks-version "0.5.1")
+(def ks-version "0.5.2")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "0.3.3-SNAPSHOT"
   :description "We are trapperkeeper.  We are one."
@@ -37,6 +37,10 @@
   :classifiers [["test" :testutils]]
 
   :test-paths ["test/clj"]
+
+  ;; this plugin is used by jenkins jobs to interrogate the project version
+  :plugins [[lein-project-version "0.1.0"]
+            [lein-release "1.0.5"]]
 
   :profiles {:dev {:test-paths ["test-resources"]
                    :source-paths ["examples/ring_app/src"


### PR DESCRIPTION
Updated CHANGELOG.

Prior to this commit, this package depended upon puppetlabs/kitchensink
0.5.1.  This commit updates the dependency version to 0.5.2.

Prior to this commit, the jenkins deploy.sh script was written to
try to commit package versioning changes on the Jenkins build machine
based on the current branch.  In this commit, the jenkins deploy.sh
script was updated to use HEAD:master instead since Jenkins runs against
a detached HEAD instead of a branch.
