### PR TITLE
(PE-3622) Tweak config format and fix bug in example

### DIFF
--- a/examples/ring_app/ring-example.conf
+++ b/examples/ring_app/ring-example.conf
@@ -1,18 +1,18 @@
-global {
+global: {
     # Points to a logback config file
     logging-config: examples/ring_app/logback.xml
 }
 
-nrepl {
+nrepl: {
     enabled: true
 }
 
-webserver {
+webserver: {
     # Port to listen on for clear-text HTTP.
     port: 8080
 }
 
-example {
+example: {
     # The URL prefix at which the ernie service should be available in the web server.
     ernie-url-prefix: /ernie
 }

--- a/examples/ring_app/src/examples/ring_app/example_services.clj
+++ b/examples/ring_app/src/examples/ring_app/example_services.clj
@@ -11,8 +11,7 @@
          (string? endpoint)]
    :post [(integer? %) (> % 0)]}
 
-  (let [new-hit-counts (swap! hit-counts update-in [endpoint] (fnil inc 0))]                                                             (inc (% endpoint)) :else 1)))]
-
+  (let [new-hit-counts (swap! hit-counts update-in [endpoint] (fnil inc 0))]
     (log/debug "Incrementing hit count for" endpoint "from"
                (dec (new-hit-counts endpoint)) "to" (new-hit-counts endpoint))
 

--- a/examples/servlet_app/servlet-example.conf
+++ b/examples/servlet_app/servlet-example.conf
@@ -1,9 +1,9 @@
-global {
+global: {
     # Points to a logback config file
     logging-config: examples/servlet_app/logback.xml
 }
 
-webserver {
+webserver: {
     host: 0.0.0.0
     port: 8080
 }

--- a/examples/war_app/war-example.conf
+++ b/examples/war_app/war-example.conf
@@ -1,9 +1,9 @@
-global {
+global: {
     # Points to a logback configuration file
     logging-config: examples/war_app/logback.xml
 }
 
-webserver {
+webserver: {
     host: 0.0.0.0
     port: 8080
 }


### PR DESCRIPTION
This commit makes a slight tweak to our "canonical" config examples,
to use a colon before the definition of a map.  This keeps us a
little closer to the standard JSON format.

I also found a bug in the ring example code and fixed it.
