### PR TITLE
(TK-22) Fix for Jetty9 service shutdown error when not first inited

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -37,7 +37,8 @@
 
   (stop [this context]
         (log/info "Shutting down web server.")
-        (core/shutdown (context :jetty9-server))
+        (if-let [server (:jetty9-server context)]
+          (core/shutdown server))
         context)
 
   (add-context-handler [this base-path context-path]


### PR DESCRIPTION
This commit adds a simple check in the Jetty9 service's `stop` function
which avoids calling the `core/shutdown` function if no `:jetty9-server`
is attached to the context.  This avoids a schema violation `Exception`
which would otherwise be thrown for any case where the Jetty9 service's
`stop` function were called without the Jetty9 service's `init` function
first being called.  The prior `Exception` would have only occurred if
another service had thrown a `Throwable` from its `init` function and the
Jetty9 service's `init` function had not already been called.
