### PR TITLE
WIP - TK Proxy fixes - REVIEW ONLY

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def tk-version "0.4.2")
-(def ks-version "0.7.1")
+(def ks-version "0.7.2")
+(def jetty-version "9.1.0.v20131115")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "0.5.3-SNAPSHOT"
   :description "We are trapperkeeper.  We are one."
@@ -9,7 +10,7 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.logging "0.2.6"]
-                 [prismatic/schema "0.2.1"]
+                 [prismatic/schema "0.2.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/certificate-authority "0.1.5"]
@@ -17,12 +18,12 @@
                  [javax.servlet/javax.servlet-api "3.1.0"]
 
                  ;; Jetty Webserver
-                 [org.eclipse.jetty/jetty-server "9.1.0.v20131115"
+                 [org.eclipse.jetty/jetty-server ~jetty-version
                   :exclusions [org.eclipse.jetty.orbit/javax.servlet]]
-                 [org.eclipse.jetty/jetty-servlet "9.1.0.v20131115"]
-                 [org.eclipse.jetty/jetty-servlets "9.1.0.v20131115"]
-                 [org.eclipse.jetty/jetty-webapp "9.1.0.v20131115"]
-                 [org.eclipse.jetty/jetty-proxy "9.1.0.v20131115"]
+                 [org.eclipse.jetty/jetty-servlet ~jetty-version]
+                 [org.eclipse.jetty/jetty-servlets ~jetty-version]
+                 [org.eclipse.jetty/jetty-webapp ~jetty-version]
+                 [org.eclipse.jetty/jetty-proxy ~jetty-version]
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api]]]
                    
@@ -50,7 +51,7 @@
                                   "examples/war_app/src"]
                    :java-source-paths ["examples/servlet_app/src/java"
                                        "test/java"]
-                   :dependencies [[puppetlabs/http-client "0.1.7"]
+                   :dependencies [[puppetlabs/http-client "0.2.0-SNAPSHOT"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]


### PR DESCRIPTION
For now, this is a review-only PR showing what changes are required for the pe-trapperkeeper-proxy.
- This PR
- bumps schema version to support the Bool type (needed in dependent projects)
- moves jetty version to a variable to enable easy jetty version change
- bumps version of the http client
- enables using the latest jetty client (a workaround with the Logger creation is needed)
- adds another hook in the add-proxy-route which enables changing the URI early enough in case of redirection (AFAIK request in the callback-fn cannot change its hostname), if we say that we'll always redirect within the same hostname then we can try to merge this hook into the callback-fn as well
- adds support for authorization via the 'authorize-fn' callback function which can either grant access to the target URI, or send a redirect to a different URI (typically the "forbidden" page)

Note: The documentation is not updated (regarding the add-proxy-route) since this is just a proposal of adding yet another callback function and I am not sure if it's acceptable. If not then we can try to live with the original callback-fn only but we'll be limited in actions that can be done if user is not authorized to visit the target URL. Ideas are welcome!
