### PR TITLE
(TK-43) Fix query param issue with proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Alternatively, if you did this:
    [[:WebserverService add-ring-handler]]
    ;; initialization
    (init [this context]
-      (add-ring-handler my-app "/my-app" {:server-id :ziggy})
+      (add-ring-handler my-app "/my-app" {:server-id :foo})
       context))
 ```
-it would add your ring handler to the server with id `:ziggy` at endpoint "/my-app",
+it would add your ring handler to the server with id `:foo` at endpoint "/my-app",
 rather than the `:default` server.
 
 *NOTE FOR COMPOJURE APPS*: If you are using compojure, it's important to note

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -146,7 +146,7 @@ webserver: {
         port: 9000
     }
 
-    ziggy: {
+    foo: {
         host: localhost
         port: 10000
     }

--- a/examples/multiserver_app/multiserver-example.conf
+++ b/examples/multiserver_app/multiserver-example.conf
@@ -11,7 +11,7 @@ webserver: {
     default: {
         port: 8080
     }
-    ziggy: {
+    foo: {
         port: 9000
     }
 }

--- a/examples/multiserver_app/src/examples/multiserver_app/example_services.clj
+++ b/examples/multiserver_app/src/examples/multiserver_app/example_services.clj
@@ -25,19 +25,19 @@
     (log/info "Initializing hello webservice")
     (let [url-prefix (get-in-config [:hello-web :url-prefix])]
       ; Since we're using the -to versions of the below functions and are specifying
-      ; server-id :ziggy, these will be added to the :ziggy server specified in the
+      ; server-id :foo, these will be added to the :foo server specified in the
       ; config file.
       (add-proxy-route
         {:host "localhost"
          :port 8080
          :path "/hello"}
         "/hello"
-        {:server-id :ziggy})
+        {:server-id :foo})
       (add-ring-handler
         (fn [req]
           {:status 200
            :headers {"Content-Type" "text/plain"}
            :body "Goodbye world"})
         "/goodbye"
-        {:server-id :ziggy})
+        {:server-id :foo})
       (assoc context :url-prefix url-prefix))))

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -290,15 +290,13 @@
                          :http "http"
                          :https "https"))
               context-path (.getPathInfo req)
-              uri (str scheme "://" (:host target) ":" (:port target)
-                       "/" (:path target) context-path)]
-          (if query
-            (-> uri
-                (.concat "?")
-                (.concat query)
-                (.toString)
-                (URI/create))
-            (URI/create (.toString uri)))))
+              uri (StringBuilder. (str scheme "://" (:host target)
+                                       ":" (:port target)
+                                       "/" (:path target) context-path))]
+          (when query
+            (.append uri "?")
+            (.append uri query))
+          (URI/create (.toString uri))))
 
       (newHttpClient []
         (let [client (if custom-ssl-ctxt-factory

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
@@ -33,7 +33,7 @@
             add-context-handler (partial add-context-handler s)
             path                   "/resources"
             resource               "logback.xml"]
-        (add-context-handler dev-resources-dir path {:server-id :ziggy})
+        (add-context-handler dev-resources-dir path {:server-id :foo})
         (let [response (http-get (str "http://localhost:8085" path "/" resource))]
           (is (= (:status response) 200))
           (is (= (:body response) (slurp (str dev-resources-dir resource))))))))
@@ -84,7 +84,7 @@
             body                   "Hey there"
             path                   "/hey"
             servlet                (SimpleServlet. body)]
-        (add-servlet-handler servlet path {:server-id :ziggy})
+        (add-servlet-handler servlet path {:server-id :foo})
         (let [response (http-get
                          (str "http://localhost:8085" path))]
           (is (= (:status response) 200))
@@ -151,7 +151,7 @@
             add-war-handler    (partial add-war-handler s)
             path               "/test"
             war                "helloWorld.war"]
-        (add-war-handler (str dev-resources-dir war) path {:server-id :ziggy})
+        (add-war-handler (str dev-resources-dir war) path {:server-id :foo})
         (let [response (http-get (str "http://localhost:8085" path "/hello"))]
           (is (= (:status response) 200))
           (is (= (:body response)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_override_settings_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_override_settings_test.clj
@@ -85,7 +85,7 @@
                               (init [this context]
                                     (reset! override-result
                                             (override-webserver-settings!
-                                              :ziggy overrides))
+                                              :foo overrides))
                                     context))]
         (with-test-logging
           (with-app-with-config
@@ -97,7 +97,7 @@
                   body                "Hi World"
                   path                "/hi_world"
                   ring-handler        (fn [req] {:status 200 :body body})]
-              (add-ring-handler ring-handler path {:server-id :ziggy})
+              (add-ring-handler ring-handler path {:server-id :foo})
               (let [response (http-get
                                (format "https://localhost:%d%s/" ssl-port path)
                                default-options-for-https-client)]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -99,7 +99,7 @@
             body             "Hi World"
             path             "/hi_world"
             ring-handler (fn [req] {:status 200 :body body})]
-        (add-ring-handler ring-handler path {:server-id :ziggy})
+        (add-ring-handler ring-handler path {:server-id :foo})
         (add-ring-handler ring-handler path {:server-id :default})
         (let [response1 (http-get "http://localhost:8080/hi_world/" {:as :text})
               response2 (http-get "http://localhost:8085/hi_world/" {:as :text})]
@@ -368,7 +368,7 @@
                                      context))
             app              (boot-service-and-jetty-with-multiserver-config
                                test-service)
-            jetty-server1     (get-jetty-server-from-app-context app :ziggy)
+            jetty-server1     (get-jetty-server-from-app-context app :foo)
             jetty-server2     (get-jetty-server-from-app-context app :default)]
         (is (.isStarted jetty-server1)
             "First Jetty server was never started before call to run-app")

--- a/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
@@ -11,7 +11,7 @@
   {:webserver {:port 8080}})
 
 (def jetty-multiserver-plaintext-config
-  {:webserver {:ziggy   {:port 8085}
+  {:webserver {:foo   {:port 8085}
                :default {:port 8080}}})
 
 (def jetty-ssl-jks-config


### PR DESCRIPTION
This PR fixes the issue reported by @praxxis wherein a proxy handler added with add-proxy-route would crash when given a query parameter.
