### PR TITLE
(PDB-671) Enable JMX support for Jetty 9

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -171,3 +171,9 @@ webserver: {
 ```
 
 In this case, the Jetty9 Service will simply create a single webserver and give it id `:default`.
+
+### `jmx-enabled`
+
+Optional. When enabled this setting will register the Jetty 9 MBeans so they are visible via
+JMX. Useful for monitoring the state of your Jetty 9 instance while it is running; for monitoring and
+debugging purposes. Defaults to `true`.

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,10 @@
                  [org.eclipse.jetty/jetty-servlets "9.1.0.v20131115"]
                  [org.eclipse.jetty/jetty-webapp "9.1.0.v20131115"]
                  [org.eclipse.jetty/jetty-proxy "9.1.0.v20131115"]
+                 [org.eclipse.jetty/jetty-jmx "9.1.0.v20131115"]
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api]]]
-                   
+
   :plugins [[lein-release "1.0.5"]]
 
   :lein-release {:scm         :git
@@ -54,6 +55,7 @@
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]
+                                  [org.clojure/java.jmx "0.2.0"]
                                   [spyscope "0.1.4"]]
                     :injections [(require 'spyscope.core)]}
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -19,7 +19,9 @@
            (java.net URI)
            (java.security Security)
            (org.eclipse.jetty.client HttpClient)
-           (clojure.lang Atom))
+           (clojure.lang Atom)
+           (java.lang.management ManagementFactory)
+           (org.eclipse.jetty.jmx MBeanContainer))
   (:require [ring.util.servlet :as servlet]
             [clojure.string :as str]
             [clojure.set :as set]
@@ -203,6 +205,11 @@
   [webserver-context :- ServerContext
    config :- config/WebserverConfig]
   (let [server (Server. (QueuedThreadPool. (:max-threads config)))]
+    (when (:jmx-enable config)
+      (let [mb-container (MBeanContainer. (ManagementFactory/getPlatformMBeanServer))]
+        (doto server
+          (.addEventListener mb-container)
+          (.addBean mb-container))))
     (when (:http config)
       (let [connector (plaintext-connector server (:http config))]
         (.addConnector server connector)))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -4,7 +4,8 @@
             [clojure.java.io :refer [resource]]
             [schema.core :as schema]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :refer :all]
-            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]))
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
+            [puppetlabs.kitchensink.core :refer [parse-bool]]))
 
 (def valid-ssl-pem-config
   {:ssl-cert    "./dev-resources/config/jetty/ssl/certs/localhost.pem"
@@ -20,7 +21,8 @@
 (defn expected-http-config?
   [config expected]
   (= (-> expected
-         (update-in [:max-threads] (fnil identity default-max-threads)))
+         (update-in [:max-threads] (fnil identity default-max-threads))
+         (update-in [:jmx-enable] (fnil parse-bool default-jmx-enable)))
      (process-config config)))
 
 (defn expected-https-config?
@@ -28,6 +30,7 @@
   (let [actual (process-config config)]
     (= (-> expected
            (update-in [:max-threads] (fnil identity default-max-threads))
+           (update-in [:jmx-enable] (fnil parse-bool default-jmx-enable))
            (update-in [:https :cipher-suites] (fnil identity acceptable-ciphers))
            (update-in [:https :protocols] (fnil identity default-protocols))
            (update-in [:https :client-auth] (fnil identity default-client-auth))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -2,6 +2,7 @@
   (:import
     (org.eclipse.jetty.server.handler ContextHandler ContextHandlerCollection))
   (:require [clojure.test :refer :all]
+            [clojure.java.jmx :as jmx]
             [ring.util.response :as rr]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty]
@@ -41,6 +42,17 @@
             ;; We should not receive a content-encoding header in the uncompressed case
             (is (nil? (get-in resp [:headers "content-encoding"]))
                 (format "Expected uncompressed response, got this response: %s" resp))))))))
+
+(deftest jmx
+  (testing "by deefault Jetty JMX support is enabled"
+    (with-test-webserver #() _
+      (testing "and should return a valid Jetty MBeans object"
+        (let [mbeans (jmx/mbean-names "org.eclipse.jetty.jmx:*")]
+          (is (not (empty? mbeans)))))
+
+      (testing "and should not return data when we query for something unexpected"
+        (let [mbeans (jmx/mbean-names "foobarbaz:*")]
+          (is (empty? mbeans)))))))
 
 (deftest override-webserver-settings!-tests
   (letfn [(webserver-context [state]


### PR DESCRIPTION
This patch enables JMX support for exposing Jetty 9 metrics.

Signed-off-by: Ken Barber ken@bob.sh
