### PR TITLE
TK-48 ambigous slash when building proxy URL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
                  [org.eclipse.jetty/jetty-webapp "9.1.0.v20131115"]
                  [org.eclipse.jetty/jetty-proxy "9.1.0.v20131115"]
                  [org.eclipse.jetty/jetty-jmx "9.1.0.v20131115"]
+                 [org.apache.httpcomponents/httpclient "4.3.2"]
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api]]]
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -21,6 +21,7 @@
            (org.eclipse.jetty.client HttpClient)
            (clojure.lang Atom)
            (java.lang.management ManagementFactory)
+           (org.apache.http.client.utils URIBuilder)
            (org.eclipse.jetty.jmx MBeanContainer))
   (:require [ring.util.servlet :as servlet]
             [clojure.string :as str]
@@ -300,12 +301,12 @@
                          :http "http"
                          :https "https"))
               context-path (.getPathInfo req)
-              uri (StringBuilder. (str scheme "://" (:host target)
-                                       ":" (:port target)
-                                       "/" (:path target) context-path))]
-          (when query
-            (.append uri "?")
-            (.append uri query))
+              uri (doto (new URIBuilder)
+                    (.setScheme scheme)
+                    (.setHost (:host target))
+                    (.setPort (:port target))
+                    (.setPath context-path)
+                    (.setCustomQuery query))]
           (URI/create (.toString uri))))
 
       (newHttpClient []


### PR DESCRIPTION
This patch allows me to create clean URLs when using TK proxy which are accepted by my service.

I cannot tell whether this is correct solution, it's just a proposal. I don't think there is a way to get rid of the ambigous slash without patching TK.
