### PR TITLE
(TK-53) Add get-route service function

### DIFF
--- a/doc/webrouting-config.md
+++ b/doc/webrouting-config.md
@@ -35,7 +35,7 @@ In this case, two endpoints will be configured for the `foo-service`.
 `"/foo"` will have route-id `:default`, and `"/bar"` will have route-id
 `:bar`. Handlers can be added to the `"/bar"` endpoint by explicitly
 specifying `:bar` as the `route-id` when adding a handler. Please see
-[Trapperkeeper Webrouting Service](doc/webrouting-service.md) for
+[Trapperkeeper Webrouting Service](webrouting-service.md) for
 more information.
 
 Please note that, when configuring endpoints in this way, there must be

--- a/doc/webrouting-service.md
+++ b/doc/webrouting-service.md
@@ -44,7 +44,7 @@ file, via:
 
 The webrouting service is configured via the
 [trapperkeeper configuration service](https://github.com/puppetlabs/trapperkeeper#configuration-service).
-Please see [Configuring the Webrouting Service](doc/webrouting-config.md) for information on
+Please see [Configuring the Webrouting Service](webrouting-config.md) for information on
 how to configure the webrouting service.
 
 ### Service Protocol
@@ -53,6 +53,7 @@ This is the protocol for the current implementation of the `:WebroutingService`:
 
 ```clj
 (defprotocol WebroutingService
+  (get-route [this svc] [this svc route-id])
   (add-context-handler [this svc context-path] [this svc context-path options])
   (add-ring-handler [this svc handler] [this svc handler options])
   (add-servlet-handler [this svc servlet] [this svc servlet options])
@@ -63,6 +64,16 @@ This is the protocol for the current implementation of the `:WebroutingService`:
   (log-registered-endpoints [this] [this server-id])
   (join [this] [this server-id]))
 ```
+
+#### `get-route`
+
+This function allows you to get the web-route for a particular service
+as configured in your configuration file. The one-argument version will
+return the default web route configured for the current service. The two
+argument version will return the web route configured for the current
+service with the id you specify.
+
+#### Other functions
 
 The functions `override-webserver-settings!`, `get-registered-endpoints`,
 `log-registered-endpoints`, and `join` all work in the exact same way as
@@ -119,7 +130,7 @@ the ring handler `my-app` would be registered at endpoint `"/foo"`. However, if 
 the ring handler `my-app` would be registered at endpoint `"/bar"`.
 
 For information on how to configure multiple endpoints, please see
-[Configuring the Webrouting Service](doc/webrouting-config.md).
+[Configuring the Webrouting Service](webrouting-config.md).
 
 PLEASE NOTE that there is an issue with the `defservice` macro such that `this` cannot
 be accessed while calling the webrouting service functions. As a result, when using the

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
@@ -7,6 +7,7 @@
     [schema.core :as schema]))
 
 (defprotocol WebroutingService
+  (get-route [this svc] [this svc route-id])
   (add-context-handler [this svc context-path] [this svc context-path options])
   (add-ring-handler [this svc handler] [this svc handler options])
   (add-servlet-handler [this svc servlet] [this svc servlet options])
@@ -25,6 +26,12 @@
   (init [this context]
         (let [config (get-in-config [:web-router-service])]
           (core/init context config)))
+
+  (get-route [this svc]
+             (core/get-route (service-context this) svc nil))
+
+  (get-route [this svc route-id]
+             (core/get-route (service-context this) svc route-id))
 
   (add-context-handler [this svc base-path]
                     (core/add-context-handler! (service-context this)

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
@@ -80,6 +80,14 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Service function implementations
 
+(defn get-route
+  [context svc route-id]
+  (let [svc-id              (keyword (tk-services/service-symbol svc))
+        endpoint-and-server (get-endpoint-and-server-from-config context
+                                                                 svc-id
+                                                                 route-id)]
+    (:route endpoint-and-server)))
+
 (schema/defn ^:always-validate add-context-handler!
   [context webserver-service
    svc :- tk-services/Service

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
@@ -63,7 +63,9 @@
         :baz    {:route "/foo"
                  :server "foo"}
         :quux   {:route "/bar"
-                 :server "foo"}}}})
+                 :server "foo"}}
+      :puppetlabs.trapperkeeper.services.webrouting.webrouting-service-test/test-service-2
+       "/foo"}})
 
 (def no-default-config
   {:webserver {:bar {:port 8080}
@@ -113,5 +115,20 @@
             body             "Hello World!"
             ring-handler     (fn [req] {:status 200 :body body})
             svc              (tk-app/get-service app :TestService2)]
-        (is (thrown? IllegalArgumentException (add-ring-handler svc ring-handler)))))))
+        (is (thrown? IllegalArgumentException (add-ring-handler svc ring-handler))))))
+
+  (testing "Can access route-ids for a service"
+    (with-app-with-config
+      app
+      [jetty9-service webrouting-service test-service test-service-2]
+      webrouting-plaintext-multiserver-multiroute-config
+      (let [s         (tk-app/get-service app :WebroutingService)
+            svc       (tk-app/get-service app :TestService)
+            svc2      (tk-app/get-service app :TestService2)
+            get-route (partial get-route s)]
+        (is (= "/foo" (get-route svc)))
+        (is (= "/bar" (get-route svc :bar)))
+        (is (= "/foo" (get-route svc :baz)))
+        (is (= "/bar" (get-route svc :quux)))
+        (is (= "/foo" (get-route svc2)))))))
 


### PR DESCRIPTION
This PR adds a get-route service function to the Webrouting service. This function allows the user to pull webroutes configured for a particular service from the configuration file.
