### PR TITLE
(TK-58) Add remaining default server support

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -78,7 +78,7 @@
                    (core/add-proxy-route! (service-context this) target path options))
 
   (override-webserver-settings! [this overrides]
-                                (let [s (core/get-server-context (service-context this) :default)]
+                                (let [s (core/get-server-context (service-context this) nil)]
                                   (core/override-webserver-settings! s overrides)))
 
   (override-webserver-settings! [this server-id overrides]
@@ -86,7 +86,7 @@
                                   (core/override-webserver-settings! s overrides)))
 
   (get-registered-endpoints [this]
-                            (let [s (core/get-server-context (service-context this) :default)]
+                            (let [s (core/get-server-context (service-context this) nil)]
                               (core/get-registered-endpoints s)))
 
   (get-registered-endpoints [this server-id]
@@ -99,7 +99,7 @@
                             (log/info (str (get-registered-endpoints this server-id))))
 
   (join [this]
-        (let [s (core/get-server-context (service-context this) :default)]
+        (let [s (core/get-server-context (service-context this) nil)]
           (core/join s)))
 
   (join [this server-id]

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_override_settings_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_override_settings_test.clj
@@ -27,14 +27,6 @@
    :web-router-service
      {:puppetlabs.trapperkeeper.services.webrouting.webrouting-service-override-settings-test/test-dummy "/foo"}})
 
-(def webrouting-plaintext-multiserver-override-config
-  {:webserver {:bar {:port           8080
-                     :default-server true}
-               :foo {:port 9000}}
-   :web-router-service
-     {:puppetlabs.trapperkeeper.services.webrouting.webrouting-service-override-settings-test/test-dummy "/foo"}})
-
-
 (deftest test-override-webserver-settings!-with-web-routing
   (let [ssl-port  9001
         overrides {:ssl-port ssl-port

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
@@ -218,7 +218,7 @@
     (with-test-logging
       (with-app-with-config app
         [jetty9-service]
-        jetty-plaintext-config
+        jetty-multiserver-plaintext-config
         (let [s                        (get-service app :WebserverService)
               log-registered-endpoints (partial log-registered-endpoints s)
               add-ring-handler         (partial add-ring-handler s)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_override_settings_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_override_settings_test.clj
@@ -19,6 +19,12 @@
   {:webserver {:ssl-host "0.0.0.0"
                :ssl-port 9001}})
 
+(def jetty-plaintext-multiserver-override-config
+  {:webserver {:bar {:port           8080
+                     :default-server true}
+               :foo {:port 9000}}})
+
+
 (deftest test-override-webserver-settings!
   (let [ssl-port  9001
         overrides {:ssl-port ssl-port
@@ -49,7 +55,7 @@
           (with-app-with-config
             app
             [jetty9-service service1]
-            jetty-plaintext-config
+            jetty-plaintext-multiserver-override-config
             (let [s                (get-service app :WebserverService)
                   add-ring-handler (partial add-ring-handler s)
                   body             "Hi World"


### PR DESCRIPTION
This PR addresses a bug wherein `get-registered-endpoints`, `log-registered-endpoints`, `join`, and `override-webserver-settings!` were using a default server with a key of `:default` rather than the actual default server specified by the user. 
