### PR TITLE
(TK-69) Add new webrouting example using compojure

### DIFF
--- a/doc/webrouting-service.md
+++ b/doc/webrouting-service.md
@@ -96,10 +96,10 @@ with the Webserver service, you would call
 ```
 
 which would add the ring handler `my-app` to the endpoint `"/my-app"`. With the webrouting
-service, however, when in a service implementing the FooService protocol, you would call
+service, however, you would call
 
 ```clj
-(add-ring-handler (get-service this :FooService) my-app)
+(add-ring-handler this my-app)
 ```
 
 which would find the endpoint configured for the current service in the configuration file,
@@ -116,30 +116,24 @@ In a multiroute configuration, a route-id MUST be specified or the operation wil
 Second, `:server-id` is a disallowed key in this options map. Specifying a specific server
 to which to add an endpoint is handled in the configuration of the webrouting service.
 
-As an example, say you have two endpoints configured for a specific service, which implements
-protocol FooService. One is endpoint `"/foo"` and is kept at key `:foo`. The other is
+As an example, say you decide to add two endpoints using a specific service, and you have
+two endpoints configured for that service.
+One is endpoint `"/foo"` and is kept at key `:foo`. The other is
 endpoint `"/bar"` and is kept at key `:bar`. If you were to call
 
 ```clj
-(add-ring-handler (get-service this :FooService) my-app {:route-id :foo)
+(add-ring-handler this my-app {:route-id :foo)
 ```
 
 the ring handler `my-app` would be registered at endpoint `"/foo"`. However, if you were to call
 
 ```clj
-(add-ring-handler (get-service this :FooService) my-app {:route-id :bar})
+(add-ring-handler this my-app {:route-id :bar})
 ```
 
 the ring handler `my-app` would be registered at endpoint `"/bar"`.
 
 For information on how to configure multiple endpoints, please see
 [Configuring the Webrouting Service](webrouting-config.md).
-
-PLEASE NOTE that there is an issue with the `defservice` macro such that `this` cannot
-be accessed while calling the webrouting service functions. As a result, when using the
-webrouting service functions, you must use the `get-service` function to get the
-current service. Furthermore, because of the way `get-service` works, any service
-you want to get with it must implement a protocol, meaning any service using the webrouting
-service must implement a protocol.
 
 

--- a/examples/webrouting_app/README.md
+++ b/examples/webrouting_app/README.md
@@ -12,7 +12,7 @@ lein trampoline run --config examples/webrouting_app/webrouting-example.conf \
 Open any of
 
 ```
-http://localhost:8080/hello
+http://localhost:8080/foo
 http://localhost:8080/bar
 http://localhost:8080/baz
 http://localhost:8080/goodbye
@@ -23,3 +23,11 @@ http://localhost:9000/bert
 
 in your browser to see the famous Hello World message.
 
+Open
+
+```
+http://localhost:8080/hello/[string]
+
+```
+where [string] is any string of your choosing to see a Hello message specific for
+that string.

--- a/examples/webrouting_app/bootstrap.cfg
+++ b/examples/webrouting_app/bootstrap.cfg
@@ -5,3 +5,4 @@ examples.webrouting-app.example-services/foo-service
 examples.webrouting-app.example-services/bar-service
 examples.webrouting-app.example-services/quux-service
 examples.webrouting-app.example-services/bert-service
+examples.webrouting-app.example-services/hello-service

--- a/examples/webrouting_app/src/examples/webrouting_app/example_services.clj
+++ b/examples/webrouting_app/src/examples/webrouting_app/example_services.clj
@@ -1,49 +1,64 @@
 (ns examples.webrouting-app.example-services
   (:require [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
-            [puppetlabs.trapperkeeper.services :refer [get-services]]))
+            [puppetlabs.trapperkeeper.services :refer [get-services]]
+            [compojure.core :as compojure]
+            [compojure.route :as route]))
 
-(defn hello-app
+(defn hello-world-app
   [req]
   {:status  200
    :headers {"Content-Type" "text/plain"}
    :body    "Hello, World!"})
 
-(defprotocol FooService)
-(defprotocol BarService)
-(defprotocol QuuxService)
-(defprotocol BertService)
+(defn hello-app
+  []
+  (compojure/routes
+    (compojure/GET "/:caller" [caller]
+      (fn [req]
+        (log/info "Handling request for caller:" caller)
+        {:status  200
+         :headers {"Content-Type" "text/plain"}
+         :body    (format "Hello, %s!" caller)}))
+    (route/not-found "Not Found")))
 
 (defservice foo-service
-  FooService
   [[:WebroutingService add-ring-handler]]
   (init [this context]
     (log/info "Initializing foo service")
-    (add-ring-handler (get-service this :FooService) hello-app)
+    (add-ring-handler this hello-world-app)
     context))
 
 (defservice bar-service
-  BarService
   [[:WebroutingService add-ring-handler]]
   (init [this context]
     (log/info "Initializing bar service")
-    (add-ring-handler (get-service this :BarService) hello-app)
-    (add-ring-handler (get-service this :BarService) hello-app {:route-id :baz})
+    (add-ring-handler this hello-world-app {:route-id :bar})
+    (add-ring-handler this hello-world-app {:route-id :baz})
     context))
 
 (defservice quux-service
-  QuuxService
   [[:WebroutingService add-ring-handler]]
   (init [this context]
     (log/info "Initializing quux service")
-    (add-ring-handler (get-service this :QuuxService) hello-app)
+    (add-ring-handler this hello-world-app)
     context))
 
 (defservice bert-service
-  BertService
   [[:WebroutingService add-ring-handler]]
   (init [this context]
     (log/info "Initializing bert service")
-    (add-ring-handler (get-service this :BertService) hello-app)
-    (add-ring-handler (get-service this :BertService) hello-app {:route-id :bert})
+    (add-ring-handler this hello-world-app {:route-id :baz})
+    (add-ring-handler this hello-world-app {:route-id :bert})
+    context))
+
+(defservice hello-service
+  [[:WebroutingService add-ring-handler get-route]]
+  (init [this context]
+    (log/info "Initializing hello service")
+    (let [url-prefix (get-route this)]
+      (add-ring-handler
+        this
+        (compojure/context url-prefix []
+          (hello-app))))
     context))

--- a/examples/webrouting_app/webrouting-example.conf
+++ b/examples/webrouting_app/webrouting-example.conf
@@ -18,20 +18,21 @@ webserver: {
 }
 
 web-router-service: {
-    "examples.webrouting-app.example-services/foo-service": "/hello"
+    "examples.webrouting-app.example-services/foo-service": "/foo"
     "examples.webrouting-app.example-services/bar-service": {
-        default: "/bar"
-        baz:     "/goodbye"
+        bar: "/bar"
+        baz: "/goodbye"
     }
     "examples.webrouting-app.example-services/quux-service": {
         route:  "/quux"
         server: "quux"
     }
     "examples.webrouting-app.example-services/bert-service": {
-        default: "/baz"
+        baz:  "/baz"
         bert: {
             route: "/bert"
             server: "quux"
         }
     }
+    "examples.webrouting-app.example-services/hello-service": "/hello"
 }

--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,9 @@
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]
                                   [org.clojure/java.jmx "0.2.0"]
-                                  [spyscope "0.1.4"]]
+                                  [spyscope "0.1.4"]
+                                  [compojure "1.1.8" :exclusions [ring/ring-core
+                                                                  commons-io]]]
                     :injections [(require 'spyscope.core)]}
 
              :testutils {:source-paths ^:replace ["test/clj"]


### PR DESCRIPTION
Add a new webrouting example that adds a ring handler using
compojure that changes depending on the path it is given.
Update webrouting example and webrouting docs to use `this`
instead of `get-service` when using the webrouting service.
