### PR TITLE
(TK-75) Make Gzip encoding configurable for the Jetty webserver

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -223,6 +223,20 @@ webserver: {
 Since `follow-links` is set to true, `image-link` will now be served, and can
 be accessed by visiting `"http://localhost:8080/assets/image-link"`.
 
+### `gzip-enable`
+
+Optional. This controls whether or not the webserver could compress the
+response body for any request using Gzip encoding. A value of `false` would
+prevent the server from using Gzip encoding the response body for all requests.
+If this option is not specified or is specified with a value of `true`, the
+webserver "could" Gzip encode the response body.
+
+Note that in order for Gzip encoding to be used, a client would also need to
+include in the request an "Accept-Encoding" HTTP header containing the value
+"gzip". The webserver also may use other heuristics to avoid Gzip encoding the
+response body independent of the configuration of this setting.  For example,
+the webserver may skip compression for a sufficiently small response body.
+
 ## Configuring multiple webservers on isolated ports
 
 It is possible to configure multiple webservers on isolated ports within a single Jetty9

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -59,7 +59,8 @@
    (schema/optional-key :ssl-crl-path)               schema/Str
    (schema/optional-key :jmx-enable)                 schema/Str
    (schema/optional-key :default-server)             schema/Bool
-   (schema/optional-key :static-content)             [StaticContent]})
+   (schema/optional-key :static-content)             [StaticContent]
+   (schema/optional-key :gzip-enable)                schema/Bool})
 
 (def MultiWebserverRawConfigUnvalidated
   {schema/Keyword  WebserverRawConfig})

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -410,6 +410,8 @@
     :ssl-port                 - the SSL port to listen on (defaults to 8081)
     :max-threads              - the maximum number of threads to use (default 100)
     :request-header-max-size  - the maximum size of an HTTP request header (default 8192)
+    :gzip-enable              - whether or not gzip compression can be applied
+                                to the body of a response (default true)
 
     SSL may be configured via PEM files by providing all three of the following
     settings:
@@ -447,8 +449,12 @@
           ^Server s             (create-server webserver-context config)
           ^HandlerCollection hc (HandlerCollection.)]
     (.setHandlers hc (into-array Handler [(:handlers webserver-context)]))
-    (.setHandler s (gzip-handler hc))
-    (assoc webserver-context :server s)))
+    (let [handler-for-server (if (or (not (contains? options :gzip-enable))
+                                     (:gzip-enable options))
+                               (gzip-handler hc)
+                               hc)]
+      (.setHandler s handler-for-server)
+      (assoc webserver-context :server s))))
 
 (schema/defn ^:always-validate start-webserver! :- ServerContext
   "Creates and starts a webserver.  Returns an updated context map containing

--- a/test/clj/puppetlabs/trapperkeeper/testutils/webserver.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/webserver.clj
@@ -1,6 +1,38 @@
 (ns puppetlabs.trapperkeeper.testutils.webserver
   (:require [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty9]))
 
+(defmacro with-test-webserver-and-config
+  "Constructs and starts an embedded Jetty on a random port with a custom
+  configuration and evaluates `body` inside a try/finally block that takes
+  care of tearing down the webserver.
+
+  `app` - The ring application the webserver should serve
+
+  `port-var` - Inside of `body`, the variable named `port-var`
+  contains the port number the webserver is listening on
+
+  `config` - Configuration to use for the webserver
+
+  Example:
+
+      (let [app (constantly {:status 200 :headers {} :body \"OK\"})]
+        (with-test-webserver app port {:request-header-max-size 1024}
+          ;; Hit the embedded webserver
+          (http-client/get (format \"http://localhost:%s\" port))))"
+  [app port-var config & body]
+  `(let [srv#      (jetty9/start-webserver!
+                     (jetty9/initialize-context)
+                     (assoc ~config :port 0))
+         _#        (jetty9/add-ring-handler srv# ~app "/")
+         ~port-var (-> (:server srv#)
+                       (.getConnectors)
+                       (first)
+                       (.getLocalPort))]
+     (try
+       ~@body
+       (finally
+         (jetty9/shutdown srv#)))))
+
 (defmacro with-test-webserver
   "Constructs and starts an embedded Jetty on a random port, and
   evaluates `body` inside a try/finally block that takes care of
@@ -16,18 +48,10 @@
       (let [app (constantly {:status 200 :headers {} :body \"OK\"})]
         (with-test-webserver app port
           ;; Hit the embedded webserver
-          (http-client/get (format \"http://localhost:%s\" port))))
-  "
+          (http-client/get (format \"http://localhost:%s\" port))))"
   [app port-var & body]
-  `(let [srv#      (jetty9/start-webserver!
-                     (jetty9/initialize-context)
-                     {:port 0})
-         _#        (jetty9/add-ring-handler srv# ~app "/")
-         ~port-var (-> (:server srv#)
-                       (.getConnectors)
-                       (first)
-                       (.getLocalPort))]
-     (try
-       ~@body
-       (finally
-         (jetty9/shutdown srv#)))))
+  `(with-test-webserver-and-config
+     ~app
+     ~port-var
+     {}
+     ~@body))


### PR DESCRIPTION
This commit adds an option to the webserver configuration,
`gzip-enable`, which can be used to control whether or not the webserver
would attempt to compress the response body using Gzip encoding.
