### PR TITLE
(TK-47) Modify endpoint data structure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,8 @@
                                   [org.clojure/java.jmx "0.2.0"]
                                   [spyscope "0.1.4"]
                                   [compojure "1.1.8" :exclusions [ring/ring-core
-                                                                  commons-io]]]
+                                                                  commons-io
+                                                                  org.clojure/tools.macro]]]
                     :injections [(require 'spyscope.core)]}
 
              :testutils {:source-paths ^:replace ["test/clj"]

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_handlers_test.clj
@@ -186,7 +186,8 @@
                  "<html>\n<head><title>Hello World Servlet</title></head>\n<body>Hello World!!</body>\n</html>\n")))))))
 
 (deftest endpoints-test-web-routing
-  (testing "get-registered-endpoints is successful with the web-routing service"
+  (testing (str "get-registered-endpoints and log-registered-endpoints are "
+                "successful with the web-routing service")
     (with-test-logging
       (with-app-with-config app
         [jetty9-service
@@ -201,29 +202,9 @@
               svc                      (get-service app :TestDummy)]
           (add-ring-handler svc ring-handler)
           (let [endpoints (get-registered-endpoints)]
-            (is (= endpoints #{{:type :ring :endpoint "/foo"}})))
+            (is (= endpoints {"/foo" [{:type :ring}]})))
           (log-registered-endpoints)
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/foo\"\}\}$"))
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/foo\"\}\}$" :info))))))
-  (testing "log-registered-endpoints is successful with the web-routing service"
-    (with-test-logging
-      (with-app-with-config app
-        [jetty9-service
-         webrouting-service
-         test-dummy]
-        webrouting-plaintext-multiserver-config
-        (let [s                             (get-service app :WebroutingService)
-              get-registered-endpoints      (partial get-registered-endpoints s)
-              log-registered-endpoints      (partial log-registered-endpoints s)
-              add-ring-handler              (partial add-ring-handler s)
-              ring-handler                  (fn [req] {:status 200 :body "Hi world"})
-              server-id                     :foo
-              svc                           (get-service app :TestDummy)]
-          (add-ring-handler svc ring-handler)
-          (let [endpoints (get-registered-endpoints server-id)]
-            (is (= endpoints #{{:type :ring :endpoint "/foo"}})))
-          (log-registered-endpoints server-id)
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/foo\"\}\}$"))
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/foo\"\}\}$" :info)))))))
+          (is (logged? #"^\{\"\/foo\" \[\{:type :ring}\]\}$"))
+          (is (logged? #"^\{\"\/foo\" \[\{:type :ring}\]\}$" :info)))))))
 
 

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
@@ -240,19 +240,19 @@
         (add-proxy-route target path-proxy)
         (add-proxy-route target2 path-proxy {})
         (let [endpoints (get-registered-endpoints)]
-          (is (= endpoints #{{:type :context :base-path dev-resources-dir
-                              :endpoint path-context :context-listeners []}
-                             {:type :context :base-path dev-resources-dir
-                              :context-listeners [] :endpoint path-context2}
-                             {:type :context :base-path dev-resources-dir
-                              :context-listeners context-listeners :endpoint path-context3}
-                             {:type :ring :endpoint path-ring}
-                             {:type :servlet :servlet (type servlet) :endpoint path-servlet}
-                             {:type :war :war-path (str dev-resources-dir war) :endpoint path-war}
-                             {:type :proxy :target-host "0.0.0.0" :target-port 9000
-                              :endpoint path-proxy :target-path "/ernie"}
-                             {:type :proxy :target-host "localhost" :target-port 10000
-                              :endpoint path-proxy :target-path "/kermit"}}))))))
+          (is (= endpoints {"/ernie" [{:type :context :base-path dev-resources-dir
+                                       :context-listeners []}]
+                            "/gonzo" [{:type :context :base-path dev-resources-dir
+                                       :context-listeners []}]
+                            "/goblinking" [{:type :context :base-path dev-resources-dir
+                                            :context-listeners context-listeners}]
+                            "/bert" [{:type :ring}]
+                            "/foo" [{:type :servlet :servlet (type servlet)}]
+                            "/bar" [{:type :war :war-path (str dev-resources-dir war)}]
+                            "/baz" [{:type :proxy :target-host "0.0.0.0" :target-port 9000
+                                     :target-path "/ernie"}
+                                    {:type :proxy :target-host "localhost" :target-port 10000
+                                     :target-path "/kermit"}]}))))))
 
   (testing "Log endpoints"
     (with-test-logging
@@ -266,5 +266,5 @@
               path-ring                "/bert"]
           (add-ring-handler ring-handler path-ring)
           (log-registered-endpoints)
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/bert\"\}\}$"))
-          (is (logged? #"^\#\{\{:type :ring, :endpoint \"\/bert\"\}\}$" :info)))))))
+          (is (logged? #"^\{\"\/bert\" \[\{:type :ring\}\]\}$"))
+          (is (logged? #"^\{\"\/bert\" \[\{:type :ring\}\]\}$" :info)))))))


### PR DESCRIPTION
Modify the list of endpoints to be a map. Now, since an
endpoint can have multiple handlers registered on it,
each key in the map is an endpoint, with its value being a
vector of all the handlers registered at that endpoint.
