### PR TITLE
(TK-54) Fix multiple default servers error message

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -293,6 +293,15 @@
     acc))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private helper functions
+
+(defn validate-config
+  [config]
+  (when-not (one-default? config)
+    (throw (IllegalArgumentException.
+             "Error: More than one default server specified in configuration"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
 (schema/defn ^:always-validate

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -31,6 +31,7 @@
                          ;; Here for backward compatibility with existing projects
                          (get-in-config [:jetty])
                          {})]
+          (config/validate-config config)
           (core/init! context config)))
 
   (start [this context]


### PR DESCRIPTION
Fix multiple default servers error message to be something
readable.

TK-54 specifically mentions that the error message being caused by `schema/either` was unreadable. The validation that ensures that only one default server is specified had already been moved to `schema/pred`, but the error message was still confusing and difficult to read, so I did some explicit validation so I could throw a more readable `IllegalArgumentException`.

I did this in a `validate-config` function in the `jetty9-config` namespace so that there's a function where we can do any necessary validation that we want to happen before the schema validation (in case we want to throw more readable error messages than those thrown by schema) without cluttering up the `init` service function.
