### PR TITLE
(TK-84) Don't double encode query strings

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -26,6 +26,7 @@
            (org.eclipse.jetty.util URIUtil))
 
   (:require [ring.util.servlet :as servlet]
+            [ring.util.codec :refer [url-decode]]
             [clojure.string :as str]
             [clojure.set :as set]
             [clojure.tools.logging :as log]
@@ -325,7 +326,7 @@
                                  (:port target)
                                  (with-leading-slash
                                    (URIUtil/addPaths (:path target) context-path))
-                                 query
+                                 (url-decode (str query))
                                  nil)]
             (if-let [rewrite-uri-callback-fn (:rewrite-uri-callback-fn options)]
               (rewrite-uri-callback-fn target-uri req)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
@@ -464,6 +464,23 @@
           (is (= (:status response) 200))
           (is (= (:body response) (str {"foo" "bar"}))))))
 
+    (testing "basic proxy support with url encodable query parameters"
+      (with-target-and-proxy-servers
+        {:target       {:host "0.0.0.0"
+                        :port 9000}
+         :proxy        {:host "0.0.0.0"
+                        :port 10000}
+         :proxy-config {:host "localhost"
+                        :port 9000
+                        :path "/hello"}
+         :ring-handler app-wrapped}
+        (let [response (http-get "http://localhost:9000/hello?hello%5B%5D=hello%20world")]
+          (is (= (:status response) 200))
+          (is (= (:body response) (str {"hello[]" "hello world"}))))
+        (let [response (http-get "http://localhost:10000/hello-proxy?hello%5B%5D=hello%20world")]
+          (is (= (:status response) 200))
+          (is (= (:body response) (str {"hello[]" "hello world"}))))))
+
     (testing "basic proxy support with multiple query parameters"
       (let [params {"foo"   "bar"
                     "baz"   "lux"


### PR DESCRIPTION
The Java URI class encodes the "query" parameter when using its
multi-parameter constructor. In proxy-servlet we are using getQueryString
to get the query string to pass into URI, which does not URL decode the
query string. This change decodes the query string before passing it into
the URI class, which will then go ahead and reencode it.
