### PR TITLE
(TK-92) Add graceful-shutdown support

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -252,10 +252,10 @@ directory. It will log the remote host making the request, the log name, the rem
 the request, the date/time of the request, the URL and method of the request, the status of
 the response, and the size in bytes of the response.
 
-### `graceful-shutdown-timeout`
+### `shutdown-timeout-seconds`
 
-Optional. This is an integer representing the desired graceful stop timeout in milliseconds.
-Defaults to 30000 ms.
+Optional. This is an integer representing the desired graceful stop timeout in seconds.
+Defaults to 60 seconds.
 
 ## Configuring multiple webservers on isolated ports
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -64,7 +64,7 @@
    (schema/optional-key :static-content)             [StaticContent]
    (schema/optional-key :gzip-enable)                schema/Bool
    (schema/optional-key :access-log-config)          schema/Str
-   (schema/optional-key :graceful-shutdown-timeout)  schema/Int})
+   (schema/optional-key :shutdown-timeout-seconds)   schema/Int})
 
 (def MultiWebserverRawConfigUnvalidated
   {schema/Keyword  WebserverRawConfig})


### PR DESCRIPTION
Add graceful-shutdown support to the Jetty9 Webservice. Now,
when the webserver is shutdown, the server will give open
requests a chance to resolve themselves. Allow user to
configure the graceful shutdown stop timeout.
