### PR TITLE
(TK-95) Ensure default timeout is 60 seconds

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -484,8 +484,7 @@
                                  (.setHandler maybe-logged))
                                maybe-logged)]
       (.setHandler s statistics-handler)
-      (if (not (nil? shutdown-timeout))
-        (.setStopTimeout s (or shutdown-timeout default-graceful-stop-timeout)))
+      (.setStopTimeout s (or shutdown-timeout default-graceful-stop-timeout))
       (assoc webserver-context :server s))))
 
 (schema/defn ^:always-validate start-webserver! :- ServerContext


### PR DESCRIPTION
Fix issue wherein the default shutdown timeout was 30 seconds
rather than 60 seconds.

Once this gets merged, I'm planning to do a release so I can update the dependencies in https://github.com/puppetlabs/ezbake/pull/127.
