### PR TITLE
(TK-98) Add test to ensure SSLv3 isn't supported (FOR REVIEW)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [prismatic/schema "0.2.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/certificate-authority "0.5.0"]
+                 [puppetlabs/certificate-authority "0.6.0"]
 
                  [ch.qos.logback/logback-access "1.1.1"]
 
@@ -27,7 +27,7 @@
                  [org.eclipse.jetty/jetty-proxy "9.1.0.v20131115"]
                  [org.eclipse.jetty/jetty-jmx "9.1.0.v20131115"]
 
-                 [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api]]]
+                 [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api commons-codec]]]
 
   :plugins [[lein-release "1.0.5"]]
 
@@ -54,7 +54,7 @@
                                   "examples/webrouting_app/src"]
                    :java-source-paths ["examples/servlet_app/src/java"
                                        "test/java"]
-                   :dependencies [[puppetlabs/http-client "0.2.9-SNAPSHOT"]
+                   :dependencies [[puppetlabs/http-client "0.3.1"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -718,7 +718,7 @@
         (start-server nil)
         (is (= 0 (count (logs-matching #"known vulnerabilities" @logs))))))))
 
-(deftest sslv3-unsupported-test
+(deftest sslv3-support-test
   (testing "SSLv3 is not supported by default"
     (with-app-with-config
       app
@@ -731,4 +731,17 @@
         (is (thrown?
               ConnectionClosedException
               (http-get "https://localhost:8081/hello" (merge default-options-for-https-client
-                                                              {:ssl-protocols ["SSLv3"]}))))))))
+                                                              {:ssl-protocols ["SSLv3"]})))))))
+  (testing "SSLv3 is supported when configured"
+    (with-app-with-config
+      app
+      [jetty9-service]
+      (assoc-in jetty-ssl-pem-config [:webserver :ssl-protocols] ["SSLv3"])
+      (let [s                (tk-app/get-service app :WebserverService)
+            add-ring-handler (partial add-ring-handler s)
+            ring-handler     (fn [_] {:status 200 :body "Hello, World!"})]
+        (add-ring-handler ring-handler "/hello")
+        (let [response (http-get "https://localhost:8081/hello" (merge default-options-for-https-client
+                                                                       {:ssl-protocols ["SSLv3"]}))]
+          (is (= (:status response) 200))
+          (is (= (:body response) "Hello, World!")))))))


### PR DESCRIPTION
Add a test to ensure that SSLv3 isn't supported by TK Jetty9
webservers by default.

I'm throwing this up now for review. However, it depends on https://github.com/puppetlabs/clj-http-client/pull/20 getting merged and clj-http-client getting released so that the dependency can be bumped to a non-SNAPSHOT version.
