### PR TITLE
(TK-130) Dynamic default for max-threads set

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -360,12 +360,12 @@
   otherwise use the default."
   [config   :- WebserverRawConfig
    num-cpus :- schema/Int]
-  (let [calc-max-threads (max (calculate-required-threads config num-cpus)
-                              default-max-threads)]
-    (or (:max-threads config)
-        (do (log/warn "Thread pool size not configured so using a size of "
-                      calc-max-threads)
-            calc-max-threads))))
+  (or (:max-threads config)
+      (let [calc-max-threads (max (calculate-required-threads config num-cpus)
+                                  default-max-threads)]
+        (log/warn "Thread pool size not configured so using a size of "
+                  calc-max-threads)
+        calc-max-threads)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -276,7 +276,9 @@
      :port         (or (:port config) default-http-port)
      :request-header-max-size (or (:request-header-max-size config) default-request-header-size)}))
 
-(schema/defn contains-https-connector? [config]
+(schema/defn ^:always-validate
+  contains-https-connector? :- schema/Bool
+  [config :- WebserverRawConfig]
   (contains-keys? config #{:ssl-port :ssl-host}))
 
 (schema/defn ^:always-validate

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -344,7 +344,7 @@
 (schema/defn ^:always-validate
   calculate-required-threads :- schema/Int
   "Calculate the number threads needed to operate based on the number of cores
-  abvailable and the number of connectors present."
+  available and the number of connectors present."
   [config   :- WebserverRawConfig
    num-cpus :- schema/Int]
   (+ 1 (* (connector-count config)

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -330,8 +330,8 @@
 (defn threads-per-connector
   "The total number of threads needed per attached connector."
   [num-cpus]
-  (+ 1 (acceptors-count num-cpus)
-       (selectors-count num-cpus)))
+  (+ (acceptors-count num-cpus)
+     (selectors-count num-cpus)))
 
 (schema/defn ^:always-validate
   connector-count :- schema/Int
@@ -347,8 +347,8 @@
   abvailable and the number of connectors present."
   [config   :- WebserverRawConfig
    num-cpus :- schema/Int]
-  (* (connector-count config)
-     (threads-per-connector num-cpus)))
+  (+ 1 (* (connector-count config)
+          (threads-per-connector num-cpus))))
 
 (schema/defn ^:always-validate
   determine-max-threads :- schema/Int

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -342,7 +342,7 @@
     (count (filter true? connectors))))
 
 (schema/defn ^:always-validate
-  calculate-minimum-threads :- schema/Int
+  calculate-required-threads :- schema/Int
   "Calculate the number threads needed to operate based on the number of cores
   abvailable and the number of connectors present."
   [config   :- WebserverRawConfig
@@ -358,7 +358,7 @@
   otherwise use the default."
   [config   :- WebserverRawConfig
    num-cpus :- schema/Int]
-  (let [calc-max-threads (max (calculate-minimum-threads config num-cpus)
+  (let [calc-max-threads (max (calculate-required-threads config num-cpus)
                               default-max-threads)]
     (or (:max-threads config)
         (do (log/warn "Thread pool size not configured so using a size of "

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -260,17 +260,29 @@
                  ssl-crl-path))))))
 
 (schema/defn ^:always-validate
+  contains-keys? :- schema/Bool
+  [config :- WebserverRawConfig
+   keys   :- #{schema/Keyword}]
+  (boolean (some #(contains? config %) keys)))
+
+(defn contains-http-connector? [config]
+  (contains-keys? config #{:port :host}))
+
+(schema/defn ^:always-validate
   maybe-get-http-connector :- (schema/maybe WebserverConnector)
   [config :- WebserverRawConfig]
-  (if (some #(contains? config %) #{:port :host})
+  (if (contains-http-connector? config)
     {:host         (or (:host config) default-host)
      :port         (or (:port config) default-http-port)
      :request-header-max-size (or (:request-header-max-size config) default-request-header-size)}))
 
+(schema/defn contains-https-connector? [config]
+  (contains-keys? config #{:ssl-port :ssl-host}))
+
 (schema/defn ^:always-validate
   maybe-get-https-connector :- (schema/maybe WebserverSslConnector)
   [config :- WebserverRawConfig]
-  (if (some #(contains? config %) #{:ssl-port :ssl-host})
+  (if (contains-https-connector? config)
     {:host (or (:ssl-host config) default-host)
      :port (or (:ssl-port config) default-https-port)
      :request-header-max-size (or (:request-header-max-size config) default-request-header-size)
@@ -305,6 +317,54 @@
     (throw (IllegalArgumentException.
              "Error: More than one default server specified in configuration"))))
 
+(defn selectors-count
+  "The number of selector threads that should be allocated per connector per core."
+  [num-cpus]
+  num-cpus)
+
+(defn acceptors-count
+  "The number of acceptor threads that should be allocated per connector per core."
+  [num-cpus]
+  (max 1 (int (/ num-cpus 2))))
+
+(defn threads-per-connector
+  "The total number of threads needed per attached connector."
+  [num-cpus]
+  (+ 1 (acceptors-count num-cpus)
+       (selectors-count num-cpus)))
+
+(schema/defn ^:always-validate
+  connector-count :- schema/Int
+  "Return the number of connectors found in the config."
+  [config :- WebserverRawConfig]
+  (let [connectors [(contains-http-connector? config)
+                    (contains-https-connector? config)]]
+    (count (filter true? connectors))))
+
+(schema/defn ^:always-validate
+  calculate-minimum-threads :- schema/Int
+  "Calculate the number threads needed to operate based on the number of cores
+  abvailable and the number of connectors present."
+  [config   :- WebserverRawConfig
+   num-cpus :- schema/Int]
+  (* (connector-count config)
+     (threads-per-connector num-cpus)))
+
+(schema/defn ^:always-validate
+  determine-max-threads :- schema/Int
+  "Determine the size of the Jetty thread pool. If the size is specified in the
+  config then use that value, otherwise determine the minimum number of threads
+  needed to operate. If that number is larger than the default then use it,
+  otherwise use the default."
+  [config   :- WebserverRawConfig
+   num-cpus :- schema/Int]
+  (let [calc-max-threads (max (calculate-minimum-threads config num-cpus)
+                              default-max-threads)]
+    (or (:max-threads config)
+        (do (log/warn "Thread pool size not configured so using a size of "
+                      calc-max-threads)
+            calc-max-threads))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -314,7 +374,7 @@
   (let [result (-> {}
                    (maybe-add-http-connector config)
                    (maybe-add-https-connector config)
-                   (assoc :max-threads (get config :max-threads default-max-threads))
+                   (assoc :max-threads (determine-max-threads config (num-cpus)))
                    (assoc :jmx-enable (parse-bool (get config :jmx-enable default-jmx-enable))))]
     (when-not (some #(contains? result %) [:http :https])
       (throw (IllegalArgumentException.

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -254,10 +254,10 @@
                                      valid-ssl-pem-config)))))
 
   (testing "The number of threads per connector"
-    (is (= 3 (threads-per-connector 1)))
-    (is (= 4 (threads-per-connector 2)))
-    (is (= 5 (threads-per-connector 3)))
-    (is (= 7 (threads-per-connector 4))))
+    (is (= 2 (threads-per-connector 1)))
+    (is (= 3 (threads-per-connector 2)))
+    (is (= 4 (threads-per-connector 3)))
+    (is (= 6 (threads-per-connector 4))))
 
   (testing "Number of acceptors per cpu"
     (is (= 1 (acceptors-count 1)))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -265,6 +265,10 @@
     (is (= 1 (acceptors-count 3)))
     (is (= 2 (acceptors-count 4))))
 
+  (testing "Number of selectors per cpu"
+    (doseq [n (range 42)]
+      (is (= n (selectors-count n)))))
+
   (testing "The default number of threads are returned."
     (is (= default-max-threads (determine-max-threads {} 1)))
     (is (= default-max-threads (determine-max-threads

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -306,4 +306,9 @@
       (doseq [{:keys [config exp-re]} [config-1 config-2]]
         (is (thrown-with-msg?
               java.lang.IllegalStateException exp-re
-              (jetty9/start-webserver! (jetty9/initialize-context) config)))))))
+              (jetty9/start-webserver! (jetty9/initialize-context) config))
+            (str "The current method that the Jetty9 service uses to calculate "
+                 "the minimum size of a thread pool has drifted from how Jetty "
+                 "itself calculates the size. This is most likely due to a "
+                 "change of the Jetty version being used. The
+                 calculate-required-threads function should be updated."))))))


### PR DESCRIPTION
On machines with a large number of cores, the default thread pool size
of 100 is too small. This commit will calculate the minimum number of
threads needed to run, and use that as the max-threads value if one
isn't already set in the configuration.