### PR TITLE
(TK-82) Added `queue-max-size` setting

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -22,6 +22,16 @@ This sets the maximum number of threads assigned to responding to HTTP and HTTPS
 requests, effectively changing how many concurrent requests can be made at one
 time. Defaults to 100.
 
+### `queue-max-size`
+
+This can be used to set an upper-bound on the size of the worker queue that the
+web server uses to temporarily store incoming client connections before they
+can be serviced.  This value defaults to "unbounded".  A request which is
+rejected by the web server because the queue is full would be seen by the
+client as having initially connected to the server socket at the TCP layer but
+having been closed almost immediately afterward by the server with no HTTP
+layer response body.
+
 ### `request-header-max-size`
 
 This sets the maximum size of an HTTP Request Header. If a header is sent

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -31,6 +31,7 @@
 (def default-jmx-enable "true")
 (def default-request-header-buffer-size 8192)
 (def default-request-header-size 8192)
+(def default-queue-max-size (Integer/MAX_VALUE))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -44,6 +45,7 @@
   {(schema/optional-key :port)                       schema/Int
    (schema/optional-key :host)                       schema/Str
    (schema/optional-key :max-threads)                schema/Int
+   (schema/optional-key :queue-max-size)             schema/Int
    (schema/optional-key :request-header-max-size)    schema/Int
    (schema/optional-key :ssl-port)                   schema/Int
    (schema/optional-key :ssl-host)                   schema/Str
@@ -126,6 +128,7 @@
     {(schema/optional-key :http)  WebserverConnector
      (schema/optional-key :https) WebserverSslConnector
      :max-threads                 schema/Int
+     :queue-max-size              schema/Int
      :jmx-enable                  schema/Bool}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -377,6 +380,7 @@
                    (maybe-add-http-connector config)
                    (maybe-add-https-connector config)
                    (assoc :max-threads (determine-max-threads config (num-cpus)))
+                   (assoc :queue-max-size (get config :queue-max-size default-queue-max-size))
                    (assoc :jmx-enable (parse-bool (get config :jmx-enable default-jmx-enable))))]
     (when-not (some #(contains? result %) [:http :https])
       (throw (IllegalArgumentException.

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -28,6 +28,7 @@
             [ring.util.codec :as codec]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :as config]
             [schema.core :as schema]))
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -131,19 +131,26 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
 
-(def default-graceful-stop-timeout 60000)
-
-(def default-request-idle-timeout
-  1000)
+(def default-graceful-stop-timeout
+  "The default number of milliseconds that is allowed for requests active at
+  the time the server is stopped to remain running until the server shuts
+  down."
+  60000)
 
 (def default-proxy-idle-timeout
   "The default number of milliseconds to wait before the proxy gives up on the
   upstream server if the :idle-timeout value isn't set in the proxy config."
   60000)
 
-(def default-queue-idle-timeout 60000)
+(def default-queue-idle-timeout
+  "The maximum number of milliseconds that a thread in the queue can remain
+  idle before the thread may be thrown away.  A value less than or equal to 0
+  would allow a thread to remain idle indefinitely."
+  60000)
 
-(def default-queue-min-threads 8)
+(def default-queue-min-threads
+  "The minimum number of threads to create and maintain in the queue."
+  8)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utility Functions
@@ -267,9 +274,7 @@
   queue-thread-pool :- QueuedThreadPool
   [max-threads :- schema/Int
    queue-max-size :- schema/Int]
-  (let [queue-min-size (if (> default-queue-min-threads queue-max-size)
-                         queue-max-size
-                         default-queue-min-threads)]
+  (let [queue-min-size (min default-queue-min-threads queue-max-size)]
     (QueuedThreadPool. max-threads
                        queue-min-size
                        default-queue-idle-timeout

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -25,6 +25,7 @@
   [config expected]
   (= (-> expected
          (update-in [:max-threads] (fnil identity default-max-threads))
+         (update-in [:queue-max-size] (fnil identity default-queue-max-size))
          (update-in [:jmx-enable] (fnil ks/parse-bool default-jmx-enable))
          (update-in [:http :request-header-max-size] (fnil identity default-request-header-size)))
      (process-config config)))
@@ -34,6 +35,7 @@
   (let [actual (process-config config)]
     (= (-> expected
            (update-in [:max-threads] (fnil identity default-max-threads))
+           (update-in [:queue-max-size] (fnil identity default-queue-max-size))
            (update-in [:jmx-enable] (fnil ks/parse-bool default-jmx-enable))
            (update-in [:https :cipher-suites] (fnil identity acceptable-ciphers))
            (update-in [:https :protocols] (fnil identity default-protocols))
@@ -64,7 +66,14 @@
 
     (is (expected-http-config?
           {:port 8000 :request-header-max-size 16192}
-          {:http {:host default-host :port 8000 :request-header-max-size 16192}})))
+          {:http {:host default-host
+                  :port 8000
+                  :request-header-max-size 16192}}))
+
+    (is (expected-http-config?
+          {:port 8000 :queue-max-size 123}
+          {:http {:host default-host :port 8000}
+           :queue-max-size 123})))
 
   (testing "process-config successfully builds a WebserverConfig for ssl connector"
     (is (expected-https-config?

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -318,14 +318,15 @@
           test-2   {:port 0, :host "0.0.0.0"}
           config-2 (small-thread-pool-size-test-config test-2)]
       (doseq [{:keys [config exp-re]} [config-1 config-2]]
-        (is (thrown-with-msg?
-              java.lang.IllegalStateException exp-re
-              (jetty9/start-webserver! (jetty9/initialize-context) config))
-            (str "The current method that the Jetty9 service uses to calculate "
-                 "the minimum size of a thread pool has drifted from how Jetty "
-                 "itself calculates the size. This is most likely due to a "
-                 "change of the Jetty version being used. The
-                 calculate-required-threads function should be updated.")))))
+        (with-test-logging
+          (is (thrown-with-msg?
+                IllegalStateException exp-re
+                (jetty9/start-webserver! (jetty9/initialize-context) config))
+              (str "The current method that the Jetty9 service uses to calculate "
+                   "the minimum size of a thread pool has drifted from how Jetty "
+                   "itself calculates the size. This is most likely due to a "
+                   "change of the Jetty version being used. The
+                   calculate-required-threads function should be updated."))))))
 
   (testing "Our thread pool size algo still allows Jetty to start"
     (let [test-1   (merge valid-ssl-pem-config {:port 0, :host "0.0.0.0"

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -1,13 +1,12 @@
 (ns puppetlabs.trapperkeeper.services.webserver.jetty9-core-test
-  (:import
-    (org.eclipse.jetty.server.handler ContextHandler ContextHandlerCollection))
+  (:import (org.eclipse.jetty.server.handler ContextHandlerCollection))
   (:require [clojure.test :refer :all]
             [clojure.java.jmx :as jmx]
             [ring.util.response :as rr]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty]
             [puppetlabs.trapperkeeper.testutils.webserver
-              :refer [with-test-webserver with-test-webserver-and-config]]))
+             :refer [with-test-webserver with-test-webserver-and-config]]))
 
 (deftest handlers
   (testing "create-handlers should allow for handlers to be added"
@@ -174,3 +173,73 @@
                 :overrides                 {:myoverride "my-override-value"}}
                @(:state context))
             "config unexpectedly changed for override-webserver-settings!")))))
+
+(defn get-thread-pool-and-queue-for-create-server
+  [max-threads queue-max-size]
+  (let [server           (jetty/create-server {:state (atom nil)
+                                               :handlers
+                                                 (ContextHandlerCollection.)
+                                               :server nil}
+                                              {:http {:port 0
+                                                      :host "0.0.0.0"
+                                                      :request-header-max-size
+                                                        100}
+                                               :jmx-enable false
+                                               :max-threads max-threads
+                                               :queue-max-size queue-max-size})
+        thread-pool      (.getThreadPool server)
+        ;; Using reflection here because the .getQueue method is protected
+        ;; and I didn't see any other way to pull the queue back from
+        ;; the thread pool.
+        get-queue-method (-> thread-pool
+                             (.getClass)
+                             (.getDeclaredMethod "getQueue" nil))
+        _                (.setAccessible get-queue-method true)
+        queue            (.invoke get-queue-method thread-pool nil)]
+    {:thread-pool thread-pool
+     :queue queue}))
+
+(deftest create-server-tests
+  (testing "thread pool given proper values"
+    (testing "max threads passed through"
+      (dotimes [x 5]
+        (let [{:keys [thread-pool]}
+          (get-thread-pool-and-queue-for-create-server x 1)]
+          (is (= x (.getMaxThreads thread-pool))
+              "Unexpected max threads for queue"))))
+
+    (testing "default idle timeout passed through"
+      (let [{:keys [thread-pool]}
+             (get-thread-pool-and-queue-for-create-server 42 1)]
+        (is (= jetty/default-queue-idle-timeout
+               (.getIdleTimeout thread-pool)))))
+
+    (testing "when queue-max-size less than default-queue-min-threads"
+      (let [max-threads    23
+            queue-min-size (dec jetty/default-queue-min-threads)
+            {:keys [thread-pool queue]}
+              (get-thread-pool-and-queue-for-create-server max-threads
+                                                           queue-min-size)]
+        (is (= max-threads (.getMaxThreads thread-pool))
+            "Unexpected max threads for thread pool")
+        (is (= queue-min-size (.getMinThreads thread-pool))
+            "Unexpected min threads for queue")
+        (is (= queue-min-size (.getCapacity queue))
+            "Unexpected initial capacity for queue")
+        (is (= queue-min-size (.getMaxCapacity queue))
+            "Unexpected max capacity for queue")))
+
+    (testing "when queue-max-size greater than default-queue-min-threads"
+      (let [max-threads    42
+            queue-min-size (inc jetty/default-queue-min-threads)
+            {:keys [thread-pool queue]}
+            (get-thread-pool-and-queue-for-create-server max-threads
+                                                         queue-min-size)]
+        (is (= max-threads (.getMaxThreads thread-pool))
+            "Unexpected max threads for thread pool")
+        (is (= jetty/default-queue-min-threads (.getMinThreads thread-pool))
+            "Unexpected min threads for queue")
+        (is (= jetty/default-queue-min-threads (.getCapacity queue))
+            "Unexpected initial capacity for queue")
+        (is (= queue-min-size (.getMaxCapacity queue))
+            "Unexpected max capacity for queue")))))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -1,12 +1,16 @@
 (ns puppetlabs.trapperkeeper.services.webserver.jetty9-core-test
-  (:import (org.eclipse.jetty.server.handler ContextHandlerCollection))
+  (:import
+    (org.eclipse.jetty.server.handler ContextHandlerCollection)
+    (org.apache.http ConnectionClosedException)
+    (java.util.concurrent ExecutionException))
   (:require [clojure.test :refer :all]
             [clojure.java.jmx :as jmx]
             [ring.util.response :as rr]
-            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.http.client.sync :as http-sync]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty]
             [puppetlabs.trapperkeeper.testutils.webserver
-             :refer [with-test-webserver with-test-webserver-and-config]]))
+              :refer [with-test-webserver with-test-webserver-and-config]]
+            [puppetlabs.kitchensink.core :as ks]))
 
 (deftest handlers
   (testing "create-handlers should allow for handlers to be added"
@@ -22,7 +26,7 @@
 (defn validate-gzip-encoding-when-gzip-requested
   [body port]
   ;; The client/get function asks for compression by default
-  (let [resp (http-client/get (format "http://localhost:%d/" port))]
+  (let [resp (http-sync/get (format "http://localhost:%d/" port))]
     (is (= (slurp (resp :body)) body))
     (is (= (get-in resp [:orig-content-encoding]) "gzip")
         (format "Expected gzipped response, got this response: %s"
@@ -31,7 +35,7 @@
 (defn validate-no-gzip-encoding-when-gzip-not-requested
   [body port]
   ;; The client/get function asks for compression by default
-  (let [resp (http-client/get (format "http://localhost:%d/" port)
+  (let [resp (http-sync/get (format "http://localhost:%d/" port)
                               {:decompress-body false})]
     (is (= (slurp (resp :body)) body))
     ;; We should not receive a content-encoding header in the
@@ -43,7 +47,7 @@
 (defn validate-no-gzip-encoding-even-though-gzip-requested
   [body port]
   ;; The client/get function asks for compression by default
-  (let [resp (http-client/get (format "http://localhost:%d/" port))]
+  (let [resp (http-sync/get (format "http://localhost:%d/" port))]
     (is (= (slurp (resp :body)) body))
     ;; We should not receive a content-encoding header in the
     ;; uncompressed case
@@ -243,3 +247,56 @@
             "Unexpected initial capacity for queue")
         (is (= queue-min-size (.getMaxCapacity queue))
             "Unexpected max capacity for queue")))))
+
+(defn get-responses
+  [num-requests port]
+  (doall (for [_ (range num-requests)]
+           (future
+             (http-sync/get
+               (str "http://localhost:"
+                    port
+                    "/hello")
+               {:as :text})))))
+
+(deftest queue-max-size-tests
+  (testing "queue-max-size"
+    (let [response-body  "hello world"
+          app            (fn [_]
+                           (Thread/sleep 5000)
+                           (-> response-body
+                               (rr/response)
+                               (rr/status 200)
+                               (rr/content-type "text/plain")
+                               (rr/charset "UTF-8")))
+          ;; Jetty needs at least num-cpus entries (and likely a bit more) in
+          ;; the queue in order to boot up successfully.  Jetty does some
+          ;; priming of selector threads using the queue independently of
+          ;; any incoming requests, for example.
+          queue-max-size (* (ks/num-cpus) 2)
+          ;; For the fail case, need to generate some number of concurrent
+          ;; requests in excess of the size of the queue in order for the queue
+          ;; to be completely filled and for some requests to start being
+          ;; dropped
+          num-requests   (+ queue-max-size 30)]
+      (testing "of default (infinite) size doesn't lead to any request fails"
+        (with-test-webserver-and-config
+          app port {:shutdown-timeout-seconds 0}
+          (let [responses (get-responses num-requests port)]
+            (doseq [response responses]
+              (is (= 200 (:status @response))
+                  "Unsuccessful response status for one request")
+              (is (= response-body (:body @response))
+                  "Unsuccessful response body for one request")))))
+      (testing "of sufficiently low queue-max-size causes some requests to fail"
+        (with-test-webserver-and-config
+          app port {:queue-max-size queue-max-size
+                    :shutdown-timeout-seconds 0}
+          (let [responses (doall (get-responses num-requests port))]
+            (is (some #(try
+                        @%
+                        false
+                        (catch ExecutionException e
+                          (instance? ConnectionClosedException
+                                     (.. e getCause))))
+                      responses)
+                "Didn't encounter connection close for any requests")))))))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -686,7 +686,8 @@
         (with-open [async-client (async/create-client {})]
           (let [response (http-client-common/get async-client "http://localhost:8080/hello" {:as :text})]
             @in-request-handler
-            (tk-app/stop app)
+            (with-test-logging
+              (tk-app/stop app))
             (is (not (nil? (:error @response)))))))))
 
   (testing "no graceful shutdown when stop timeout is set to 0"


### PR DESCRIPTION
This commit adds a `queue-max-size` setting for helping control the maximum number of incoming connections that can be queued by the webserver before any new connections are dropped.