### PR TITLE
(SERVER-101) Upgrade jvm-ca dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [prismatic/schema "0.2.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/certificate-authority "0.6.0"]
+                 [puppetlabs/ssl-utils "0.7.0"]
 
                  [ch.qos.logback/logback-access "1.1.1"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.0.0")
+(def tk-version "1.0.1")
 (def ks-version "1.0.0")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.1.1-SNAPSHOT"
@@ -75,4 +75,3 @@
 
   :main puppetlabs.trapperkeeper.main
   )
-

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -7,7 +7,7 @@
   (:require [clojure.tools.logging :as log]
             [me.raynes.fs :as fs]
             [schema.core :as schema]
-            [puppetlabs.certificate-authority.core :as ssl]
+            [puppetlabs.ssl-utils.core :as ssl]
             [puppetlabs.kitchensink.core :refer [missing? num-cpus uuid parse-bool]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -4,7 +4,7 @@
   (:require [clojure.test :refer :all]
             [clojure.java.io :refer [resource]]
             [me.raynes.fs :as fs]
-            [puppetlabs.certificate-authority.core :as ssl]
+            [puppetlabs.ssl-utils.core :as ssl]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
@@ -338,4 +338,3 @@
         (let [ctxt (jetty9/start-webserver! (jetty9/initialize-context) config)]
           (is (= (type (:server ctxt)) org.eclipse.jetty.server.Server))
           (jetty9/shutdown ctxt))))))
-


### PR DESCRIPTION
This updates the jvm-ca dependency to reflect the name change.

This also updates the Trapperkeeper dependency to the newest version.