### PR TITLE
(TK-140) Expose so-linger-seconds setting for webserver connectors

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -43,7 +43,11 @@ header is being sent in an HTTP Request.
 
 This sets the TCP SO_LINGER time, in seconds, that the webserver uses for
 underlying socket connections.  Values less than 0 result in SO_LINGER
-being disabled.
+being disabled.  Defaults to -1, i.e., "disabled".  For a more detailed
+description of what it means to have SO_LINGER disabled vs. enabled for some
+number of seconds, see http://man7.org/linux/man-pages/man7/socket.7.html.  Note
+that the effect of setting this option may vary depending upon the operating
+system's underlying implementation.
 
 ### `ssl-host`
 

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -39,6 +39,12 @@ that exceeds this value, Jetty will return an HTTP 413 Error response. This
 defaults to 8192 bytes, and only needs to be configured if an exceedingly large
 header is being sent in an HTTP Request.
 
+### `so-linger-seconds`
+
+This sets the TCP SO_LINGER time, in seconds, that the webserver uses for
+underlying socket connections.  Values less than 0 result in SO_LINGER
+being disabled.
+
 ### `ssl-host`
 
 This sets the hostname to listen on for _encrypted_ HTTPS traffic. If not

--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,7 @@
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]
                                   [org.clojure/java.jmx "0.2.0"]
-                                  [spyscope "0.1.4"]
+                                  [spyscope "0.1.5" :exclusions [clj-time]]
                                   [compojure "1.1.8" :exclusions [ring/ring-core
                                                                   commons-io
                                                                   org.clojure/tools.macro]]]

--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,7 @@
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]
                                   [org.clojure/java.jmx "0.2.0"]
-                                  [spyscope "0.1.5" :exclusions [clj-time]]
+                                  [spyscope "0.1.4"]
                                   [compojure "1.1.8" :exclusions [ring/ring-core
                                                                   commons-io
                                                                   org.clojure/tools.macro]]]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -255,7 +255,8 @@
                             (AbstractConnectionFactory/getFactories
                               ssl-ctxt-factory (connection-factory request-size)))
       (.setPort (:port config))
-      (.setHost (:host config)))))
+      (.setHost (:host config))
+      (.setSoLingerTime (:so-linger-milliseconds config)))))
 
 (schema/defn ^:always-validate
   plaintext-connector :- ServerConnector
@@ -268,7 +269,8 @@
                             (config/selectors-count (ks/num-cpus))
                             (connection-factory request-size))
       (.setPort (:port config))
-      (.setHost (:host config)))))
+      (.setHost (:host config))
+      (.setSoLingerTime (:so-linger-milliseconds config)))))
 
 (schema/defn ^:always-validate
   queue-thread-pool :- QueuedThreadPool


### PR DESCRIPTION
This commit allows the TCP SO_LINGER time used by the sockets underlying
webserver connectors to be configurable via a new webserver setting
called `so-linger-seconds`.  This is an optional setting that, if not
specified, will use the legacy behavior of SO_LINGER being disabled for
webserver sockets.