### PR TITLE
(TK-144) Add support for configuring Jetty via script

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -267,6 +267,31 @@ the response, and the size in bytes of the response.
 Optional. This is an integer representing the desired graceful stop timeout in seconds.
 Defaults to 60 seconds.
 
+### `post-config-script`
+
+Optional.  This setting is for advanced use cases only, and is intended for
+debugging purposes.  You can use it to modify low-level Jetty settings that
+are not directly exposed in our normal configuration options.  In most cases,
+if you find yourself using this, it is an indicator that we need to expose
+additional settings directly in our main configuration (so please let us know!).
+Also, the implementation details of this setting may change between releases.
+
+If you do need to use this, you can set the value to a String containing some
+Java code that should be executed against the Jetty `Server` object.  This object
+will be injected into the scope of your code in a variable named `server`.
+
+Here is a pathological example that shows how you could change the port that
+your server listens on (which you could achieve in a much simpler fashion by
+using the existing `port` setting; this example is only for the purposes of
+illustration):
+
+    post-config-script: "import org.eclipse.jetty.server.ServerConnector;
+                         ServerConnector c = (ServerConnector)(server.getConnectors()[0]);
+                         c.setPort(10000);"
+
+For more info on the Jetty `Server` object model, see the
+[Jetty Javadocs](http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/Server.html).
+
 ## Configuring multiple webservers on isolated ports
 
 It is possible to configure multiple webservers on isolated ports within a single Jetty9

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.0.2-SNAPSHOT")
+(def tk-version "1.1.0")
 (def ks-version "1.0.0")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.1.2-SNAPSHOT"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.0.1")
+(def tk-version "1.0.2-SNAPSHOT")
 (def ks-version "1.0.0")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.1.2-SNAPSHOT"
@@ -12,12 +12,15 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.logging "0.2.6"]
+                 [clj-time "0.5.1"]
                  [prismatic/schema "0.2.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/ssl-utils "0.7.0"]
 
                  [ch.qos.logback/logback-access "1.1.1"]
+
+                 [org.codehaus.janino/janino "2.7.8"]
 
                  [javax.servlet/javax.servlet-api "3.1.0"]
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -546,6 +546,8 @@
                                maybe-logged)]
       (.setHandler s statistics-handler)
       (.setStopTimeout s (or shutdown-timeout default-graceful-stop-timeout))
+      (when-let [script (:post-config-script options)]
+        (config/execute-post-config-script! s script))
       (assoc webserver-context :server s))))
 
 (schema/defn ^:always-validate start-webserver! :- ServerContext


### PR DESCRIPTION
A problem that we have had a few times with Jetty is that, in order to try to
make it easy for our users to manage the application without having to be Jetty
experts, we run Jetty embedded and only surface a subset of its configuration
options that we believe the users might care about.

This provides a pretty nice UX in cases where we've plumbed the appropriate
settings through into our config before shipping a build, but, it can be
problematic when we are trying to debug a customer issue and we discover a
potentially-relevant Jetty setting that we haven't wired through to our
configuration files... it means that we can't toggle the Jetty config setting
without shipping them a new build.

After discovering how logback supports some basic Java scripting in their
EvaluatorFilters (via a library called Janino), it occurred to me that we might
be able to support something similar for our Jetty configuration.

This commit does that.  It creates a setting called 'post-config-script', which
can be used for advanced use cases to provide some code to manipulate a Jetty
`Server` object programatically. This should theoretically allow us to cobble
together some sample configuration to ship to users who already have a build
installed that can modify basically any setting that is available in Jetty.

Use cases for this setting would hopefully be temporary, and when we find new
Jetty settings that we determine would be valuable to users, we can just plumb
them through to our normal configuration for the next release, but this would
give users a workaround that doesn't require us to ship them a whole new build
in the interim.