### PR TITLE
(MAINT) Update deps and options for running SSLv3 unit tests

### DIFF
--- a/dev-resources/java.security
+++ b/dev-resources/java.security
@@ -1,0 +1,44 @@
+#
+# This is the "override security properties file" which is used by default
+# in the lein dev profile.  End users may override java security properties in
+# a similar manner in the production code.
+#
+# This file augments and overrides $JAVA_HOME/jre/lib/security/java.security
+# when the java process is provided the option,
+# -Djava.security.properties=./dev-resources/java.security
+#
+# NOTE: It is possible to make this file authoritative, discarding the values
+# in $JAVA_HOME/jre/lib/security/java.security by setting the first character
+# of the path to an '=' sign.
+#
+# Algorithm restrictions for Secure Socket Layer/Transport Layer Security
+# (SSL/TLS) processing
+
+# In some environments, certain algorithms or key lengths may be undesirable
+# when using SSL/TLS.  This section describes the mechanism for disabling
+# algorithms during SSL/TLS security parameters negotiation, including
+# protocol version negotiation, cipher suites selection, peer authentication
+# and key exchange mechanisms.
+#
+# Disabled algorithms will not be negotiated for SSL/TLS connections, even
+# if they are enabled explicitly in an application.
+#
+# For PKI-based peer authentication and key exchange mechanisms, this list
+# of disabled algorithms will also be checked during certification path
+# building and validation, including algorithms used in certificates, as
+# well as revocation information such as CRLs and signed OCSP Responses.
+# This is in addition to the jdk.certpath.disabledAlgorithms property above.
+#
+# See the specification of "jdk.certpath.disabledAlgorithms" for the
+# syntax of the disabled algorithm string.
+#
+# Note: This property is currently used by Oracle's JSSE implementation.
+# It is not guaranteed to be examined and used by other implementations.
+#
+# Example:
+#   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
+#
+# Disable no algorithms so that unit tests are able to exercise the behavior of
+# the system when the end user explicitly configures deprecated algorithms like
+# SSLv3.
+jdk.tls.disabledAlgorithms=

--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,9 @@
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.2.6"]
+                 [clj-time "0.5.1"]
                  [prismatic/schema "0.2.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
@@ -66,7 +67,9 @@
                                   [compojure "1.1.8" :exclusions [ring/ring-core
                                                                   commons-io
                                                                   org.clojure/tools.macro]]]
-                    :injections [(require 'spyscope.core)]}
+                    :injections [(require 'spyscope.core)]
+                    ; Enable SSLv3 for unit tests that exercise SSLv3
+                    :jvm-opts ["-Djava.security.properties=./dev-resources/java.security"]} 
 
              :testutils {:source-paths ^:replace ["test/clj"]
                          :java-source-paths ^:replace ["test/java"]}


### PR DESCRIPTION
This commit bumps the dependencies in the project.clj file.  clj-time is
specifically pinned to 0.5.1 for compatibility with other current
Trapperkeeper library dependencies and to avoid the conflict that was
being pulled in from spyscope's dependency on clj-time.  The clojure
dependency was bumped to 1.6.0 since other Trapperkeeper projects are
incrementally having this bumped as well.

This commit also applies a technique first done in SERVER-332 to enable
the ability to run SSLv3-based unit tests on newer JDK versions that
disable the use of SSLv3 by default.