### PR TITLE
(TK-151) Add idle timeout setting

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -55,6 +55,8 @@ This optional setting can be used to control how long Jetty will allow a
 connection to be held open by a client without any activity on the socket.  If
 a connection is idle for longer than this value, Jetty will forcefully close
 it from the server side.  Jetty's default value for this setting is 30 seconds.
+Note that Jetty will not automatically close the connection if the idle timeout
+is reached while Jetty is still actively processing a client request.
 
 ### `ssl-host`
 

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -49,6 +49,13 @@ number of seconds, see http://man7.org/linux/man-pages/man7/socket.7.html.  Note
 that the effect of setting this option may vary depending upon the operating
 system's underlying implementation.
 
+### `idle-timeout-milliseconds`
+
+This optional setting can be used to control how long Jetty will allow a
+connection to be held open by a client without any activity on the socket.  If
+a connection is idle for longer than this value, Jetty will forcefully close
+it from the server side.  Jetty's default value for this setting is 30 seconds.
+
 ### `ssl-host`
 
 This sets the hostname to listen on for _encrypted_ HTTPS traffic. If not

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -58,6 +58,7 @@
    (schema/optional-key :queue-max-size)             schema/Int
    (schema/optional-key :request-header-max-size)    schema/Int
    (schema/optional-key :so-linger-seconds)          schema/Int
+   (schema/optional-key :idle-timeout-milliseconds)  schema/Int
    (schema/optional-key :ssl-port)                   schema/Int
    (schema/optional-key :ssl-host)                   schema/Str
    (schema/optional-key :ssl-key)                    schema/Str
@@ -120,7 +121,8 @@
 
 (def WebserverConnectorCommon
   {:request-header-max-size schema/Int
-   :so-linger-milliseconds  schema/Int})
+   :so-linger-milliseconds  schema/Int
+   :idle-timeout-milliseconds (schema/maybe schema/Int)})
 
 (def WebserverConnector
   (merge WebserverConnectorCommon
@@ -325,7 +327,8 @@
   [config :- WebserverRawConfig]
   {:request-header-max-size   (or (:request-header-max-size config)
                                   default-request-header-size)
-   :so-linger-milliseconds    (so-linger-in-milliseconds config)})
+   :so-linger-milliseconds    (so-linger-in-milliseconds config)
+   :idle-timeout-milliseconds (:idle-timeout-milliseconds config)})
 
 (schema/defn ^:always-validate
   maybe-get-http-connector :- (schema/maybe WebserverConnector)

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -242,13 +242,34 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Jetty Server / Connector Functions
 
-(defn- connection-factory
-  [request-header-size]
+(defn- connection-factories
+  [request-header-size ssl-ctxt-factory]
   (let [http-config (doto (HttpConfiguration.)
                       (.setSendDateHeader true)
-                      (.setRequestHeaderSize request-header-size))]
-    (into-array ConnectionFactory
-                [(HttpConnectionFactory. http-config)])))
+                      (.setRequestHeaderSize request-header-size))
+        factories   (into-array ConnectionFactory
+                                [(HttpConnectionFactory. http-config)])]
+    (if ssl-ctxt-factory
+      (AbstractConnectionFactory/getFactories
+        ssl-ctxt-factory factories)
+      factories)))
+
+(schema/defn ^:always-validate
+  connector* :- ServerConnector
+  [server :- Server
+   config :- (merge config/WebserverConnector
+                    {schema/Keyword schema/Any})
+   ssl-ctxt-factory :- (schema/maybe SslContextFactory)]
+  (let [request-size (:request-header-max-size config)]
+    (doto (ServerConnector.
+            server
+            nil nil nil
+            (config/acceptors-count (ks/num-cpus))
+            (config/selectors-count (ks/num-cpus))
+            (connection-factories request-size ssl-ctxt-factory))
+      (.setPort (:port config))
+      (.setHost (:host config))
+      (.setSoLingerTime (:so-linger-milliseconds config)))))
 
 (schema/defn ^:always-validate
   ssl-connector  :- ServerConnector
@@ -256,30 +277,13 @@
   [server            :- Server
    ssl-ctxt-factory  :- SslContextFactory
    config :- config/WebserverSslConnector]
-  (let [request-size (:request-header-max-size config)]
-    (doto (ServerConnector. server
-                            nil nil nil
-                            (config/acceptors-count (ks/num-cpus))
-                            (config/selectors-count (ks/num-cpus))
-                            (AbstractConnectionFactory/getFactories
-                              ssl-ctxt-factory (connection-factory request-size)))
-      (.setPort (:port config))
-      (.setHost (:host config))
-      (.setSoLingerTime (:so-linger-milliseconds config)))))
+  (connector* server config ssl-ctxt-factory))
 
 (schema/defn ^:always-validate
   plaintext-connector :- ServerConnector
   [server :- Server
    config :- config/WebserverConnector]
-  (let [request-size (:request-header-max-size config)]
-    (doto (ServerConnector. server
-                            nil nil nil
-                            (config/acceptors-count (ks/num-cpus))
-                            (config/selectors-count (ks/num-cpus))
-                            (connection-factory request-size))
-      (.setPort (:port config))
-      (.setHost (:host config))
-      (.setSoLingerTime (:so-linger-milliseconds config)))))
+  (connector* server config nil))
 
 (schema/defn ^:always-validate
   queue-thread-pool :- QueuedThreadPool

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -57,7 +57,7 @@
        (-> actual
            (update-in [:https] dissoc :keystore-config)))))
 
-(deftest process-config-test
+(deftest process-config-http-test
   (testing "process-config successfully builds a WebserverConfig for plaintext connector"
     (is (expected-http-config?
           {:port 8000}
@@ -96,8 +96,9 @@
     (is (expected-http-config?
           {:port 8000 :idle-timeout-milliseconds 6000}
           {:http {:host default-host :port 8000
-                  :idle-timeout-milliseconds 6000}})))
+                  :idle-timeout-milliseconds 6000}}))))
 
+(deftest process-config-https-test
   (testing "process-config successfully builds a WebserverConfig for ssl connector"
     (is (expected-https-config?
           (merge valid-ssl-pem-config
@@ -154,14 +155,16 @@
                   :ssl-port 8001
                   :idle-timeout-milliseconds 4200})
           {:https {:host "foo.local" :port 8001
-                   :idle-timeout-milliseconds 4200}})))
+                   :idle-timeout-milliseconds 4200}}))))
 
+(deftest process-config-jks-test
   (testing "jks ssl config"
     (is (expected-https-config?
           (merge valid-ssl-keystore-config
                  {:ssl-port 8001})
-          {:https {:host default-host :port 8001}})))
+          {:https {:host default-host :port 8001}}))))
 
+(deftest process-config-ciphers-test
   (testing "cipher suites"
     (is (expected-https-config?
           (merge valid-ssl-pem-config
@@ -178,8 +181,9 @@
           {:https
             {:host default-host
              :port 8001
-             :cipher-suites ["FOO" "BAR"]}})))
+             :cipher-suites ["FOO" "BAR"]}}))))
 
+(deftest process-config-protocols-test
   (testing "protocols"
     (is (expected-https-config?
           (merge valid-ssl-pem-config
@@ -196,7 +200,9 @@
           {:https
             {:host default-host
              :port 8001
-             :protocols ["FOO" "BAR"]}})))
+             :protocols ["FOO" "BAR"]}}))))
+
+(deftest process-config-crl-test
   (testing "ssl-crl-path"
     (is (expected-https-config?
           (merge valid-ssl-pem-config
@@ -206,8 +212,9 @@
           {:https
             {:host default-host
              :port 8001
-             :ssl-crl-path "./dev-resources/config/jetty/ssl/certs/ca.pem"}})))
+             :ssl-crl-path "./dev-resources/config/jetty/ssl/certs/ca.pem"}}))))
 
+(deftest process-config-client-auth-test
   (testing "client auth"
     (letfn [(get-client-auth [config]
                              (-> config
@@ -229,8 +236,9 @@
             unsupported value is specified for the client-auth option"
         (is (thrown-with-msg? java.lang.IllegalArgumentException
                               #"Unexpected value found for client auth config option: bogus.  Expected need, want, or none."
-                              (get-client-auth {:ssl-port 8081 :client-auth "bogus"}))))))
+                              (get-client-auth {:ssl-port 8081 :client-auth "bogus"})))))))
 
+(deftest process-config-http-plus-https-test
   (testing "process-config successfully builds a WebserverConfig for plaintext+ssl"
     (is (expected-https-config?
           (merge valid-ssl-pem-config
@@ -240,8 +248,9 @@
                    :request-header-max-size default-request-header-size
                    :so-linger-milliseconds -1
                    :idle-timeout-milliseconds nil}
-           :https {:host "foo.local" :port default-https-port}})))
+           :https {:host "foo.local" :port default-https-port}}))))
 
+(deftest process-config-invalid-test
   (testing "process-config fails for invalid server config"
     (are [config]
       (thrown? ExceptionInfo

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_handlers_test.clj
@@ -297,5 +297,5 @@
         (let [response (http-get "http://localhost:8080/hello" {:as :text
                                                                 :follow-redirects false})]
           (is (= (:status response) 302))
-          (is (= (get-in response [:headers "location"] "http://localhost:8080/hello/")))
+          (is (= (get-in response [:headers "location"]) "http://localhost:8080/hello/"))
           (is (= (get-in response [:opts :url]) "http://localhost:8080/hello")))))))


### PR DESCRIPTION
This PR adds support for a new setting, `idle-timeout-milliseconds`, which can be used to control how long Jetty will allow a client connection to remain open with no activity.