### PR TITLE
(TK-178) Upgrade Jetty dependency to 9.2.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def tk-version "1.1.0")
 (def ks-version "1.0.0")
+(def jetty-version "9.2.10.v20150310")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.2.1-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
@@ -25,13 +26,13 @@
                  [javax.servlet/javax.servlet-api "3.1.0"]
 
                  ;; Jetty Webserver
-                 [org.eclipse.jetty/jetty-server "9.2.10.v20150310"
+                 [org.eclipse.jetty/jetty-server ~jetty-version
                   :exclusions [org.eclipse.jetty.orbit/javax.servlet]]
-                 [org.eclipse.jetty/jetty-servlet "9.2.10.v20150310"]
-                 [org.eclipse.jetty/jetty-servlets "9.2.10.v20150310"]
-                 [org.eclipse.jetty/jetty-webapp "9.2.10.v20150310"]
-                 [org.eclipse.jetty/jetty-proxy "9.2.10.v20150310"]
-                 [org.eclipse.jetty/jetty-jmx "9.2.10.v20150310"]
+                 [org.eclipse.jetty/jetty-servlet ~jetty-version]
+                 [org.eclipse.jetty/jetty-servlets ~jetty-version]
+                 [org.eclipse.jetty/jetty-webapp ~jetty-version]
+                 [org.eclipse.jetty/jetty-proxy ~jetty-version]
+                 [org.eclipse.jetty/jetty-jmx ~jetty-version]
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api commons-codec]]]
 

--- a/project.clj
+++ b/project.clj
@@ -25,13 +25,13 @@
                  [javax.servlet/javax.servlet-api "3.1.0"]
 
                  ;; Jetty Webserver
-                 [org.eclipse.jetty/jetty-server "9.2.8.v20150217"
+                 [org.eclipse.jetty/jetty-server "9.2.10.v20150310"
                   :exclusions [org.eclipse.jetty.orbit/javax.servlet]]
-                 [org.eclipse.jetty/jetty-servlet "9.2.8.v20150217"]
-                 [org.eclipse.jetty/jetty-servlets "9.2.8.v20150217"]
-                 [org.eclipse.jetty/jetty-webapp "9.2.8.v20150217"]
-                 [org.eclipse.jetty/jetty-proxy "9.2.8.v20150217"]
-                 [org.eclipse.jetty/jetty-jmx "9.2.8.v20150217"]
+                 [org.eclipse.jetty/jetty-servlet "9.2.10.v20150310"]
+                 [org.eclipse.jetty/jetty-servlets "9.2.10.v20150310"]
+                 [org.eclipse.jetty/jetty-webapp "9.2.10.v20150310"]
+                 [org.eclipse.jetty/jetty-proxy "9.2.10.v20150310"]
+                 [org.eclipse.jetty/jetty-jmx "9.2.10.v20150310"]
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api commons-codec]]]
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -383,15 +383,15 @@
 
 (defn selectors-count
   "The number of selector threads that should be allocated per connector per
-  core.  This algorithm duplicates the default that Jetty 9.2.8.v20150217 uses.
-  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.8.v20150217/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L229"
+  core.  This algorithm duplicates the default that Jetty 9.2.10.v20150310 uses.
+  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L229"
   [num-cpus]
   (max 1 (min 4 (int (/ num-cpus 2)))))
 
 (defn acceptors-count
   "The number of acceptor threads that should be allocated per connector per
-  core.  This algorithm duplicates the default that Jetty 9.2.8.v20150217 uses.
-  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.8.v20150217/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L190"
+  core.  This algorithm duplicates the default that Jetty 9.2.10.v20150310 uses.
+  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L190"
   [num-cpus]
   (max 1 (min 4 (int (/ num-cpus 8)))))
 
@@ -413,8 +413,8 @@
   calculate-required-threads :- schema/Int
   "Calculate the number threads needed to operate based on the number of cores
   available and the number of connectors present.  This algorithm duplicates
-  the default that Jetty 9.2.8.v20150217 uses.  See:
-  https://github.com/eclipse/jetty.project/blob/jetty-9.2.8.v20150217/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L334-L350"
+  the default that Jetty 9.2.10.v20150310 uses.  See:
+  https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L334-L350"
   [config   :- WebserverRawConfig
    num-cpus :- schema/Int]
   (+ 1 (* (connector-count config)

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -451,7 +451,7 @@
          (callback-fn proxy-req req)))
 
       ;; The implementation of onResponseFailure is duplicated heavily from:
-      ;; https://github.com/eclipse/jetty.project/blob/jetty-9.2.8.v20150217/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L576-L607
+      ;; https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L576-L607
       ;; The only significant difference is that a 'failure-callback-fn', if
       ;; defined in options, is invoked just prior to completing the async
       ;; context for cases that the response was not already committed upstream.

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -399,7 +399,7 @@
                 "cores.")
     (with-test-logging
       ;; We're defining the number of selectors and acceptors based on the
-      ;; defaults that Jetty 9.2.8.v20150217 uses and those are capped at 4
+      ;; defaults that Jetty 9.2.10.v20150310 uses and those are capped at 4
       ;; each.  For a single connector, the minimum number of threads that
       ;; Jetty needs to start will never be larger than 9 - 4 selectors +
       ;; 4 acceptors + 1 base thread - regardless of the number of CPU cores


### PR DESCRIPTION
This commit upgrades the tk-jetty9's Jetty dependency to 9.2.10.