### PR TITLE
(TK-148) Expose selectors and acceptors and adjust thread defaults

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -44,9 +44,6 @@ properly.  The minimum number is calculated as:
 1 "worker" thread
 ~~~~
 
-"1" is the minimum number of worker threads required to process incoming
-web requests.
-
 For example, if an _unencrypted_ port with 2 `acceptor-threads` and 3
 `selector-threads` and an _encrypted_ port with 4 `acceptor-threads` and 5
 `selector-threads` were configured with the webserver, the webserver would
@@ -57,9 +54,11 @@ than the minimum required value, server startup will fail with an
 "insufficient threads".
 
 Note that each web request must be processed on a "worker" thread which is
-separate from the acceptor and selector threads.  The configured `max-threads`
-value should allow for the maximum number of requests which are desired for the
-server be able to handle concurrently.
+separate from the acceptor and selector threads.  "1" is the minimum number of
+worker threads required to process incoming web requests.  The `max-threads`
+value should be large enough that the server can allocate all of the selector
+and acceptor threads that it needs and yet still have a sufficient number of
+worker threads left over for handling concurrent web requests.
 
 ### `queue-max-size`
 

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
                                   "examples/webrouting_app/src"]
                    :java-source-paths ["examples/servlet_app/src/java"
                                        "test/java"]
-                   :dependencies [[puppetlabs/http-client "0.4.0"]
+                   :dependencies [[puppetlabs/http-client "0.4.3"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.4"]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -247,13 +247,10 @@
   [config]
   (.getThreadPool (create-server-with-partial-http-config config)))
 
-(defn get-thread-pool-for-default-server
-  []
-  (.getThreadPool (Server.)))
+(def get-thread-pool-for-default-server (.getThreadPool (Server.)))
 
-(defn default-server-max-threads
-  []
-  (.getMaxThreads (get-thread-pool-for-default-server)))
+(def default-server-max-threads (.getMaxThreads
+                                  get-thread-pool-for-default-server))
 
 (defn get-max-threads-for-partial-http-config
   [config]
@@ -261,7 +258,7 @@
 
 (deftest create-server-max-threads-test
   (testing "default max threads passed through to thread pool"
-    (is (= (default-server-max-threads)
+    (is (= default-server-max-threads
            (get-max-threads-for-partial-http-config {:max-threads nil}))))
   (testing "custom max threads passed through to thread pool"
     (is (= 9042
@@ -275,7 +272,7 @@
                                                 (munge-http-connector-config
                                                   config))))
         default-server-min-threads        (.getMinThreads
-                                            (get-thread-pool-for-default-server))]
+                                            get-thread-pool-for-default-server)]
     (testing "default queue max size passed through to thread pool queue"
       (is (= (.getMaxCapacity (get-server-thread-pool-queue (Server.)))
              (.getMaxCapacity (get-queue-for-partial-http-config
@@ -286,7 +283,7 @@
                                 {:queue-max-size 393})))))
     (testing (str "default max threads passed through to thread pool when "
                   "queue-max-size set")
-      (is (= (default-server-max-threads)
+      (is (= default-server-max-threads
              (get-max-threads-for-partial-http-config
                {:max-threads nil, :queue-max-size 1}))))
     (testing "min threads passed through to thread pool when queue-max-size set"
@@ -294,7 +291,7 @@
              (.getMinThreads (get-thread-pool-for-partial-http-config
                                {:queue-max-size 1})))))
     (testing "idle timeout passed through to thread pool when queue-max-size set"
-      (is (= (.getIdleTimeout (get-thread-pool-for-default-server))
+      (is (= (.getIdleTimeout get-thread-pool-for-default-server)
              (.getIdleTimeout (get-thread-pool-for-partial-http-config
                                 {:queue-max-size 1})))))
     (testing (str "queue min size set on thread pool queue equal to min threads "

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
@@ -39,18 +39,22 @@ that happens, we can attempt to evaluate the impact of the change and
 react accordingly."
   (:require [clojure.test :refer :all]
             [schema.test :as schema-test]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as core])
-  (:import (org.eclipse.jetty.server HttpConfiguration ServerConnector Server)))
+  (:import (org.eclipse.jetty.server HttpConfiguration ServerConnector Server)
+           (org.eclipse.jetty.util.thread QueuedThreadPool)))
 
 (use-fixtures :once schema-test/validate-schemas)
 
-(deftest default-request-header-size-test
+(deftest default-request-header-max-size-test
   (let [http-config (HttpConfiguration.)]
-    (is (= 8192 (.getRequestHeaderSize http-config)))))
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L49
+    (is (= 8192 (.getRequestHeaderSize http-config))
+        "Unexpected default for 'request-header-max-size'")))
 
 (deftest default-proxy-http-client-settings-test
   (with-app-with-config app
@@ -71,19 +75,110 @@ react accordingly."
                           {}
                           true)
           client        (.createHttpClient proxy-servlet)]
-      (is (= 4096 (.getRequestBufferSize client)))
-      (is (= 30000 (.getIdleTimeout client)))
+      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java#L129
+      (is (= 4096 (.getRequestBufferSize client))
+          "Unexpected default for proxy 'request-buffer-size'")
+      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L268-L271
+      (is (= 30000 (.getIdleTimeout client))
+          "Unexpected default for proxy 'idle-timeout'")
       (.stop client))))
+
+(def selector-thread-count
+  "The number of selector threads that should be allocated per connector.  See:
+   https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L229"
+  (max 1 (min 4 (int (/ (ks/num-cpus) 2)))))
+
+(def acceptor-thread-count
+  "The number of acceptor threads that should be allocated per connector.  See:
+   https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L190"
+  (max 1 (min 4 (int (/ (ks/num-cpus) 8)))))
 
 (deftest default-connector-settings-test
   (let [connector (ServerConnector. (Server.))]
-    (is (= -1 (.getSoLingerTime connector)))
-    (is (= 30000 (.getIdleTimeout connector)))))
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L85
+    (is (= -1 (.getSoLingerTime connector))
+        "Unexpected default for 'so-linger-seconds'")
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L146
+    (is (= 30000 (.getIdleTimeout connector))
+        "Unexpected default for 'idle-timeout-milliseconds'")
+    (is (= acceptor-thread-count (.getAcceptors connector))
+        "Unexpected default for 'acceptor-threads' and 'ssl-acceptor-threads'")
+    (is (= selector-thread-count
+           (.getSelectorCount (.getSelectorManager connector)))
+        "Unexpected default for 'selector-threads' and 'ssl-selector-threads'")))
+
+(defn get-max-threads-for-server
+  [server]
+  (.getMaxThreads (.getThreadPool server)))
+
+(defn get-server-thread-pool-queue
+  [server]
+  (let [thread-pool      (.getThreadPool server)
+        ;; Using reflection here because the .getQueue method is protected and I
+        ;; didn't see any other way to pull the queue back from the thread pool.
+        get-queue-method (-> thread-pool
+                             (.getClass)
+                             (.getDeclaredMethod "getQueue" nil))
+        _                (.setAccessible get-queue-method true)]
+    (.invoke get-queue-method thread-pool nil)))
 
 (deftest default-server-settings-test
   (let [server (Server.)]
-    (is (= 30000 (.getStopTimeout server)))))
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java#L48
+    (is (= 30000 (.getStopTimeout server))
+        "Unexpected default for 'shutdown-timeout-seconds'")
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L67
+    (is (= 200 (get-max-threads-for-server server))
+        "Unexpected default for 'max-threads'")
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java#L117
+    (is (= (Integer/MAX_VALUE) (.getMaxCapacity
+                                 (get-server-thread-pool-queue server)))
+        "Unexpected default for 'queue-max-size'")))
 
+(def threads-per-connector
+  "The total number of threads needed per attached connector."
+  (+ acceptor-thread-count selector-thread-count))
 
+(defn calculate-minimum-required-threads
+  "Calculate the minimum number threads that a single Jetty Server instance
+  needs.  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L334-L350"
+  [connectors]
+  (+ 1 (* connectors threads-per-connector)))
 
-
+(deftest default-min-threads-settings-test
+  ;; This test just exists to validate the advice we give for the bare
+  ;; minimum number of threads that one should account for when setting the
+  ;; 'max-threads' setting for a server instance.
+  (letfn [(get-server [max-threads connectors]
+            (let [server (Server. (QueuedThreadPool. max-threads))]
+              (dotimes [_ connectors]
+                (.addConnector server (ServerConnector. server)))
+              server))
+          (insufficient-threads-msg [server]
+            (let [connectors (count (.getConnectors server))]
+              (re-pattern (str "Insufficient threads: max="
+                               (get-max-threads-for-server server)
+                               " < needed\\(acceptors="
+                               (* acceptor-thread-count connectors)
+                               " \\+ selectors="
+                               (* selector-thread-count connectors)
+                               " \\+ request=1\\)"))))]
+    (dotimes [x 5]
+      (let [connectors       (inc x)
+            required-threads (calculate-minimum-required-threads connectors)]
+        (testing (str "server with too few threads for " x " connector(s) "
+                      "fail(s) to start with expected error")
+          (let [server (-> required-threads
+                           dec
+                           (get-server connectors))]
+            (is (thrown-with-msg? IllegalStateException
+                                  (insufficient-threads-msg server)
+                                  (.start server)))))
+        (testing (str "server with minimum required threads for " x
+                      "connector(s) start(s) successfully")
+          (let [server (get-server required-threads connectors)]
+            (try
+              (.start server)
+              (is (.isStarted server))
+              (finally
+                (.stop server)))))))))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
@@ -149,6 +149,12 @@ react accordingly."
   ;; This test just exists to validate the advice we give for the bare
   ;; minimum number of threads that one should account for when setting the
   ;; 'max-threads' setting for a server instance.
+  ;;
+  ;; The tk-jetty9 server configuration allows for either one or two connectors
+  ;; to be associated with a server -- at most one plaintext port connector and
+  ;; at most one encrypted port connector.  Because of this, the test only
+  ;; validates the min-threads behavior for a server that has either one or
+  ;; two connectors.
   (letfn [(get-server [max-threads connectors]
             (let [server (Server. (QueuedThreadPool. max-threads))]
               (dotimes [_ connectors]
@@ -163,7 +169,7 @@ react accordingly."
                                " \\+ selectors="
                                (* selector-thread-count connectors)
                                " \\+ request=1\\)"))))]
-    (dotimes [x 5]
+    (dotimes [x 2]
       (let [connectors       (inc x)
             required-threads (calculate-minimum-required-threads connectors)]
         (testing (str "server with too few threads for " x " connector(s) "


### PR DESCRIPTION
This commit contains three primary changes:

1) Expose the ability to configure the number of `selector-threads` and
   `acceptor-threads` that the webserver will spin up per "port" in a
   server configuration.

2) Remove the library-imposed defaults for various thread-pool related
   settings, including: acceptor-threads, selector-threads, max-threads,
   and queue-max-size.  The service will now defer to Jetty to impose
   its own default values for these settings.

3) In the process of removing library-imposed defaults, this commit
   effectively removes the changes from TK-130.  The `max-threads` setting
   will no longer automatically be bumped up above the minimum number of
   threads that the server needs to boot if the number that the server
   tries to use is insufficient and the user had not configured an explicit
   value.  Some documentation was added to the `max-threads` setting to
   advise users on how to configure the value manually, if needed to avoid
   this error.