### PR TITLE
(TK-195) Update prismatic library dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.2.6"]
                  [clj-time "0.5.1"]
-                 [prismatic/schema "0.2.2"]
+                 [prismatic/schema "0.4.0"]
+                 [prismatic/plumbing "0.4.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/ssl-utils "0.8.0"]
@@ -36,7 +37,7 @@
 
                  [ring/ring-servlet "1.1.8" :exclusions [javax.servlet/servlet-api commons-codec]]]
 
-  :plugins [[lein-release "1.0.5"]]
+  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}
@@ -64,7 +65,7 @@
                    :dependencies [[puppetlabs/http-client "0.4.3"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
-                                  [org.clojure/tools.namespace "0.2.4"]
+                                  [org.clojure/tools.namespace "0.2.10"]
                                   [org.clojure/java.jmx "0.2.0"]
                                   [spyscope "0.1.4"]
                                   [compojure "1.1.8" :exclusions [ring/ring-core

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
@@ -100,7 +100,7 @@
 
 (schema/defn ^:always-validate add-context-handler!
   [context webserver-service
-   svc :- tk-services/Service
+   svc :- (schema/protocol tk-services/Service)
    base-path
    options :- ContextHandlerOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
@@ -109,7 +109,7 @@
 
 (schema/defn ^:always-validate add-ring-handler!
   [context webserver-service
-   svc :- tk-services/Service
+   svc :- (schema/protocol tk-services/Service)
    handler options :- RouteOption]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-ring-handler    (:add-ring-handler webserver-service)]
@@ -117,7 +117,7 @@
 
 (schema/defn ^:always-validate add-servlet-handler!
   [context webserver-service
-   svc :- tk-services/Service
+   svc :- (schema/protocol tk-services/Service)
    servlet options :- ServletHandlerOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-servlet-handler (:add-servlet-handler webserver-service)]
@@ -125,7 +125,7 @@
 
 (schema/defn ^:always-validate add-war-handler!
   [context webserver-service
-   svc :- tk-services/Service
+   svc :- (schema/protocol tk-services/Service)
    war options :- RouteOption]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-war-handler     (:add-war-handler webserver-service)]
@@ -133,7 +133,7 @@
 
 (schema/defn ^:always-validate add-proxy-route!
   [context webserver-service
-   svc :- tk-services/Service
+   svc :- (schema/protocol tk-services/Service)
    target options :- ProxyRouteOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-proxy-route     (:add-proxy-route webserver-service)]


### PR DESCRIPTION
The prismatic/plumbing and prismatic/schema library dependencies are
lagging behind the latest stable version. This will increasingly cause
conflicts in trapperkeeper projects. This patch updates the dependencies
and fixes several functions which were validating against schemas
incompatible with the new versions.

* Update project.clj dependencies
* Use protocol schema instead of the protocol object directly