### PR TITLE
(MAINT) Upgrade to ssl-utils 0.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.2.6"]
-                 [clj-time "0.5.1"]
                  [prismatic/schema "0.4.0"]
                  [prismatic/plumbing "0.4.2"]
                  [puppetlabs/kitchensink ~ks-version]

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,11 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [prismatic/schema "0.4.0"]
                  [prismatic/plumbing "0.4.2"]
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version]
+
+                 ;; Let ssl-utils bring in the clj-time dependency
                  [puppetlabs/ssl-utils "0.8.1"]
+                 [puppetlabs/kitchensink ~ks-version :exclusions [clj-time]]
+                 [puppetlabs/trapperkeeper ~tk-version :exclusions [clj-time]]
 
                  [ch.qos.logback/logback-access "1.1.1"]
 

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [prismatic/plumbing "0.4.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/ssl-utils "0.8.0"]
+                 [puppetlabs/ssl-utils "0.8.1"]
 
                  [ch.qos.logback/logback-access "1.1.1"]
 


### PR DESCRIPTION
This keeps it in line with the version used in puppet-server