### PR TITLE
(maint) add variant of websockets/close! with reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ the functions of WebSocketProtocol protocol from the
   "Returns a boolean indicating if the session is currently connected")
 (send! [this msg]
   "Send a message to the websocket client")
-(close! [this]
+(close! [this] [this code reason]
   "Close the websocket session")
 (remote-addr [this]
   "Find the remote address of a websocket client")

--- a/src/puppetlabs/experimental/websockets/client.clj
+++ b/src/puppetlabs/experimental/websockets/client.clj
@@ -8,8 +8,8 @@
     "Returns a boolean indicating if the session is currently connected")
   (send! [this msg]
     "Send a message to the websocket client")
-  (close! [this]
-    "Close the websocket session")
+  (close! [this] [this code reason]
+    "Close the websocket session.")
   (remote-addr [this]
     "Find the remote address of a websocket client")
   (ssl? [this]

--- a/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
@@ -40,6 +40,8 @@
     (-send! msg this))
   (close! [this]
     (.. this (getSession) (close)))
+  (close! [this code reason]
+    (.. this (getSession) (close code reason)))
   (remote-addr [this]
     (.. this (getSession) (getRemoteAddress)))
   (ssl? [this]


### PR DESCRIPTION
Here we extend the WebSocketProtocol to add a three-arg variant of
close! which allows for the reason we are closing a connection to
be specified.