### PR TITLE
TK-270 Restore and test for 1-arity version of websockets/close!

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
@@ -38,10 +38,11 @@
   WebSocketAdapter
   (send! [this msg]
     (-send! msg this))
-  (close! [this]
-    (.. this (getSession) (close)))
-  (close! [this code reason]
-    (.. this (getSession) (close code reason)))
+  (close!
+    ([this]
+     (.. this (getSession) (close)))
+    ([this code reason]
+     (.. this (getSession) (close code reason))))
   (remote-addr [this]
     (.. this (getSession) (getRemoteAddress)))
   (ssl? [this]


### PR DESCRIPTION
Here we correct the implementation of the WebsocketProtocol for
WebSocketSend to not stomp the arity-1 version of close!.