### PR TITLE
Add get-server to WebroutingService protocol

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
@@ -9,6 +9,7 @@
 
 (defprotocol WebroutingService
   (get-route [this svc] [this svc route-id])
+  (get-server [this svc] [this svc route-id])
   (add-context-handler [this svc context-path] [this svc context-path options])
   (add-ring-handler [this svc handler] [this svc handler options])
   (add-servlet-handler [this svc servlet] [this svc servlet options])
@@ -37,6 +38,12 @@
 
   (get-route [this svc route-id]
              (core/get-route (service-context this) svc route-id))
+
+  (get-server [this svc]
+              (core/get-server (service-context this) svc nil))
+
+  (get-server [this svc route-id]
+              (core/get-server (service-context this) svc route-id))
 
   (add-context-handler [this svc base-path]
                     (core/add-context-handler! (service-context this)

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
@@ -101,6 +101,16 @@
                                                                  route-id)]
     (:route endpoint-and-server)))
 
+(schema/defn ^:always-validate get-server :- (schema/maybe schema/Str)
+  [context
+   svc :- (schema/protocol tk-services/Service)
+   route-id]
+  (let [svc-id              (keyword (tk-services/service-symbol svc))
+        endpoint-and-server (get-endpoint-and-server-from-config context
+                                                                 svc-id
+                                                                 route-id)]
+    (:server endpoint-and-server)))
+
 (schema/defn ^:always-validate add-context-handler!
   [context webserver-service
    svc :- (schema/protocol tk-services/Service)


### PR DESCRIPTION
Here we add a get-server function that, similar to get-route, will return
the configured server for the current service with a specified id.