### PR TITLE
(MAINT) Make java.jmx a top-level dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/java.jmx "0.2.0"]
                  [org.clojure/tools.logging "0.2.6"]
                  [prismatic/schema "1.0.4"]
                  [prismatic/plumbing "0.4.2"]
@@ -68,7 +69,6 @@
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [org.clojure/tools.namespace "0.2.10"]
-                                  [org.clojure/java.jmx "0.2.0"]
                                   [spyscope "0.1.4"]
                                   [compojure "1.1.8" :exclusions [ring/ring-core
                                                                   commons-io


### PR DESCRIPTION
This commit promotes org.clojure/java.jmx from a dev profile only to a
top-level dependency.  There is no real need for the production
tk-jetty9 jar to pull in the dependency at this point.  However, we
haven't found a way to have java.jmx be included as a direct dependency
of the 'testutils' jar such that users of the 'testutils' jar wouldn't
have to declare their own redundant dependency on org.clojure/java.jmx,
which is undesirable.