### PR TITLE
(TK-338) Update CHANGELOG for 1.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.3
+## 1.5.4
 
 This is a bugfix release.
 
@@ -7,6 +7,11 @@ This is a bugfix release.
   before it can gracefully complete all of the open requests.  Ensures
   that the server will be restarted during a HUP even if the timeout
   occurs.
+
+## 1.5.3
+
+This version number was burned due to an error during the release/deploy
+process.
 
 ## 1.5.2
 


### PR DESCRIPTION
There was an error deploying version 1.5.3 to clojars; this commit
updates the CHANGELOG to reflect that, and to prepare for a 1.5.4
release.