### PR TITLE
(TK-133) Safer cleanup of mbeans during stop

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -5,8 +5,8 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache.http" level="error"/>
-    <logger name="org.eclipse.jetty" level="error"/>
+    <logger name="org.apache.http" level="warn"/>
+    <logger name="org.eclipse.jetty" level="warn"/>
 
     <root level="warn">
         <appender-ref ref="STDOUT" />

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.3.0")
+(def tk-version "1.3.1")
 (def ks-version "1.3.0")
 (def jetty-version "9.2.10.v20150310")
 
@@ -11,18 +11,21 @@
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+
+                 ;; begin version conflict resolution dependencies
+                 [org.slf4j/slf4j-api "1.7.7"]
+                 ;; end version conflict resolution dependencies
+
                  [org.clojure/java.jmx "0.2.0"]
                  [org.clojure/tools.logging "0.2.6"]
                  [prismatic/schema "1.0.4"]
-                 [prismatic/plumbing "0.4.2"]
 
-                 ;; Let ssl-utils bring in the clj-time dependency
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/kitchensink ~ks-version :exclusions [clj-time]]
-                 [puppetlabs/trapperkeeper ~tk-version :exclusions [clj-time]]
+                 [puppetlabs/kitchensink ~ks-version]
+                 [puppetlabs/trapperkeeper ~tk-version]
 
-                 [ch.qos.logback/logback-access "1.1.1"]
+                 [ch.qos.logback/logback-access "1.1.3"]
 
                  [org.codehaus.janino/janino "2.7.8"]
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -561,7 +561,8 @@
   [{:keys [server] :as webserver-context} :- ServerContext]
   (when-let [mbean-container (:mbean-container @(:state webserver-context))]
     (log/debug "Cleaning up JMX MBean container")
-    (.destroy mbean-container))
+    (.destroy mbean-container)
+    (swap! (:state webserver-context) assoc :mbean-container nil))
   (when (started? webserver-context)
     (log/info "Shutting down web server.")
     (try

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -21,7 +21,8 @@
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [schema.test :as schema-test]
-            [puppetlabs.trapperkeeper.testutils.webserver :as testutils]))
+            [puppetlabs.trapperkeeper.testutils.webserver :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as tk-log-testutils]))
 
 (use-fixtures :once
   schema-test/validate-schemas
@@ -379,19 +380,21 @@
              (.getAcceptors (first connectors)))
           "Unexpected number of acceptor threads for connector")))
   (testing "non-nil acceptors configured properly for http connector"
-    (let [server     (create-server-with-partial-http-config
-                       {:http {:acceptor-threads 42}})
+    (let [server (tk-log-testutils/with-test-logging
+                  (create-server-with-partial-http-config
+                   {:http {:acceptor-threads 42}}))
           connectors (.getConnectors server)]
       (is (= 1 (count connectors))
           "Unexpected number of connectors for server")
       (is (= 42 (.getAcceptors (first connectors)))
           "Unexpected number of acceptor threads for connector")))
   (testing "non-nil acceptors configured properly for multiple connectors"
-    (let [server (create-server-with-partial-http-and-https-config
-                   {:http  {:port 25
-                            :acceptor-threads 91}
+    (let [server (tk-log-testutils/with-test-logging
+                  (create-server-with-partial-http-and-https-config
+                   {:http {:port 25
+                           :acceptor-threads 91}
                     :https {:port 92
-                            :acceptor-threads 63}})
+                            :acceptor-threads 63}}))
           connectors (.getConnectors server)]
       (is (= 2 (count connectors))
           "Unexpected number of connectors for server")

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
@@ -45,7 +45,8 @@ react accordingly."
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as core]
-            [puppetlabs.trapperkeeper.testutils.webserver :as testutils])
+            [puppetlabs.trapperkeeper.testutils.webserver :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as tk-log-testutils])
   (:import (org.eclipse.jetty.server HttpConfiguration ServerConnector Server)
            (org.eclipse.jetty.util.thread QueuedThreadPool)))
 
@@ -182,7 +183,8 @@ react accordingly."
                            (get-server connectors))]
             (is (thrown-with-msg? IllegalStateException
                                   (insufficient-threads-msg server)
-                                  (.start server)))))
+                                  (tk-log-testutils/with-test-logging
+                                   (.start server))))))
         (testing (str "server with minimum required threads for " x
                       "connector(s) start(s) successfully")
           (let [server (get-server required-threads connectors)]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -19,9 +19,10 @@
             [puppetlabs.trapperkeeper.testutils.webserver.common :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap
              :refer [with-app-with-empty-config
-                     with-app-with-config]]
-            [puppetlabs.trapperkeeper.testutils.logging
-             :refer [with-test-logging with-log-output logs-matching]]
+                     with-app-with-config]
+             :as tk-bootstrap]
+            [puppetlabs.trapperkeeper.logging :as tk-log]
+            [puppetlabs.trapperkeeper.testutils.logging :as tk-log-testutils]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as core]
             [schema.core :as schema]
             [schema.test :as schema-test]))
@@ -29,7 +30,8 @@
 (use-fixtures :once
   ks-test-fixtures/with-no-jvm-shutdown-hooks
   schema-test/validate-schemas
-  testutils/assert-clean-shutdown)
+  testutils/assert-clean-shutdown
+  (fn [f] (tk-log/reset-logging) (f)))
 
 (def default-server-config
   {:webserver {:foo {:port 8080}
@@ -185,7 +187,7 @@
     (is (thrown-with-msg?
           IllegalArgumentException
           #"Either host, port, ssl-host, or ssl-port must be specified"
-          (with-test-logging
+          (tk-log-testutils/with-test-logging
             (with-app-with-empty-config app [jetty9-service])))
       "Did not encounter expected exception when no port specified in config")))
 
@@ -345,7 +347,7 @@
 
   (testing (str "jetty throws startup exception if non-CRL PEM is specified "
                 "as ssl-crl-path")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
       (is (thrown?
             CRLException
             (with-app-with-config
@@ -358,7 +360,7 @@
 
   (testing (str "jetty throws startup exception if ssl-crl-path refers to a "
                 "non-existent file")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
       (is (thrown-with-msg?
             IllegalArgumentException
             #"Non-readable path specified for ssl-crl-path option"
@@ -395,7 +397,7 @@
 (deftest jetty-and-dependent-service-shutdown-after-service-error
   (testing (str "jetty and any dependent services are shutdown after a"
                 "service throws an error from its start function")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
      (let [shutdown-called? (atom false)
            test-service     (tk-services/service
                               [[:WebserverService]]
@@ -424,7 +426,7 @@
   (testing (str "jetty and any dependent services are shutdown after a"
                 "service throws an error from its start function"
                 "in a multi-server set-up")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
       (let [shutdown-called? (atom false)
             test-service     (tk-services/service
                                [[:WebserverService]]
@@ -460,7 +462,7 @@
   (testing (str "jetty server instance never attached to the service context "
                 "and dependent services are shutdown after a service throws "
                 "an error from its init function")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
       (let [shutdown-called? (atom false)
             test-service     (tk-services/service
                                [[:WebserverService]]
@@ -486,7 +488,7 @@
   (testing (str "attempt to launch second jetty server on same port as "
                 "already running jetty server fails with BindException without "
                 "placing second jetty server instance on app context")
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
       (let [first-app (tk-core/boot-services-with-config
                         [jetty9-service]
                         jetty-plaintext-config)]
@@ -533,9 +535,10 @@
       [jetty9-service
        hello-webservice]
       jetty-plaintext-config
-      (let [response (http-get "http://localhost:8080/hi_world" {:headers {"Cookie" absurdly-large-cookie}
-                                                                 :as :text})]
-        (is (= (:status response) 413)))))
+      (tk-log-testutils/with-test-logging
+       (let [response (http-get "http://localhost:8080/hi_world" {:headers {"Cookie" absurdly-large-cookie}
+                                                                  :as :text})]
+         (is (= (:status response) 413))))))
 
   (testing (str "request to Jetty succeeds with a large cookie if the request header "
                 "size is properly set")
@@ -691,28 +694,29 @@
         (with-open [async-client (async/create-client {})]
           (let [response (http-client-common/get async-client "http://localhost:8080/hello" {:as :text})]
             @in-request-handler
-            (with-test-logging
+            (tk-log-testutils/with-test-logging
               (tk-app/stop app))
             (is (not (nil? (:error @response)))))))))
 
   (testing "no graceful shutdown when stop timeout is set to 0"
-    (with-app-with-config
-      app
-      [jetty9-service]
-      {:webserver {:port 8080 :shutdown-timeout-seconds 0}}
-      (let [s (tk-app/get-service app :WebserverService)
-            add-ring-handler   (partial add-ring-handler s)
-            in-request-handler (promise)
-            ring-handler       (fn [_]
-                                 (deliver in-request-handler true)
-                                 (Thread/sleep 300)
-                                 {:status 200 :body "Hello, World!"})]
-        (add-ring-handler ring-handler "/hello")
-        (with-open [async-client (async/create-client {})]
-          (let [response (http-client-common/get async-client "http://localhost:8080/hello" {:as :text})]
-            @in-request-handler
-            (tk-app/stop app)
-            (is (not (nil? (:error @response)))))))))
+    (tk-log-testutils/with-test-logging
+     (with-app-with-config
+       app
+       [jetty9-service]
+       {:webserver {:port 8080 :shutdown-timeout-seconds 0}}
+       (let [s (tk-app/get-service app :WebserverService)
+             add-ring-handler (partial add-ring-handler s)
+             in-request-handler (promise)
+             ring-handler (fn [_]
+                            (deliver in-request-handler true)
+                            (Thread/sleep 300)
+                            {:status 200 :body "Hello, World!"})]
+         (add-ring-handler ring-handler "/hello")
+         (with-open [async-client (async/create-client {})]
+           (let [response (http-client-common/get async-client "http://localhost:8080/hello" {:as :text})]
+             @in-request-handler
+             (tk-app/stop app)
+             (is (not (nil? (:error @response))))))))))
 
   (testing "tk app can still restart even if stop timeout expires"
     (let [in-request-handler? (promise)
@@ -728,7 +732,7 @@
                                    {:status 200 :body hello-body})
                                  hello-path)
                                 context))]
-      (with-test-logging
+      (tk-log-testutils/with-test-logging
        (with-app-with-config
          app
          [jetty9-service
@@ -744,6 +748,26 @@
              (is (= 200 (:status @response)))
              (is (= hello-body (:body @response))))))))))
 
+(deftest double-stop-test
+  (testing "if the stop lifecycle is called more than once, we handle that gracefully and quietly"
+    (let [log-messages (atom [])]
+      (tk-log-testutils/with-logging-to-atom tk-log/root-logger-name log-messages
+        (let [app (tk-bootstrap/bootstrap-services-with-config
+                   [jetty9-service]
+                   {:webserver {:port 8080}})]
+          (tk-app/stop app)
+          (tk-app/stop app)))
+      ;; if we try to unregister the mbeans more than once Jetty will log a bunch
+      ;; of very loud and terrifying InstanceNotFoundExceptions
+      (let [log-event-filter #(and (= :warn (:level %))
+                                   (not (nil? (:exception %)))
+                                   (re-find #"InstanceNotFoundException"
+                                            (.getClassName (:exception %))))
+            mbean-err-logs (->> @log-messages
+                                (map tk-log-testutils/event->map)
+                                (filter log-event-filter))]
+        (is (= 0 (count mbean-err-logs)))))))
+
 (deftest warn-if-sslv3-supported-test
   (letfn [(start-server [ssl-protocols]
             (let [config (if ssl-protocols
@@ -754,21 +778,23 @@
                 [jetty9-service]
                 config)))]
     (testing "warns if SSLv3 is in the protocol list"
-      (with-test-logging
+      (tk-log-testutils/with-test-logging
         (start-server ["SSLv3" "TLSv1"])
         (is (logged? #"known vulnerabilities"))))
     (testing "warns regardless of case"
-      (with-test-logging
+      (tk-log-testutils/with-test-logging
         (start-server ["sslv3"])
         (is (logged? #"known vulnerabilities"))))
     (testing "does not warn if sslv3 is not in the protocol list"
-      (with-log-output logs
+      (tk-log-testutils/with-log-output logs
         (start-server ["TLSv1"])
-        (is (= 0 (count (logs-matching #"known vulnerabilities" @logs))))))
+        (is (= 0 (count (tk-log-testutils/logs-matching
+                         #"known vulnerabilities" @logs))))))
     (testing "does not warn with default settings"
-      (with-log-output logs
+      (tk-log-testutils/with-log-output logs
         (start-server nil)
-        (is (= 0 (count (logs-matching #"known vulnerabilities" @logs))))))))
+        (is (= 0 (count (tk-log-testutils/logs-matching
+                         #"known vulnerabilities" @logs))))))))
 
 (deftest sslv3-support-test
   (testing "SSLv3 is not supported by default"
@@ -782,7 +808,7 @@
            (http-get "https://localhost:8081/hi_world" (merge default-options-for-https-client
                                                               {:ssl-protocols ["SSLv3"]}))))))
   (testing "SSLv3 is supported when configured"
-    (with-test-logging
+    (tk-log-testutils/with-test-logging
      (with-app-with-config
       app
       [jetty9-service


### PR DESCRIPTION
This commit modifies our 'stop' logic so that we won't attempt
to destroy/unregister the mbeans more than once, in the event
that 'stop' gets called multiple times by TK.

Unfortunately, the main symptom that we see when we do try to
destroy/unregister the mbeans multiple times is a slew of really
nasty log messages from Jetty, which meant that the test for this
change needed to mess with test logging stuff, which had a ripple
effect that spilled over into some other files.