### PR TITLE
(TK-124) Add option for session id caching

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -375,6 +375,12 @@ illustration):
 For more info on the Jetty `Server` object model, see the
 [Jetty Javadocs](http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/Server.html).
 
+### `cache-session-id`
+
+Optional. This is a boolean indicating whether the server should cache SSL
+session ids so it can resume a session across multiple connections. Defaults
+to true.
+
 ## Configuring multiple webservers on isolated ports
 
 It is possible to configure multiple webservers on isolated ports within a single Jetty9

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -121,7 +121,8 @@
    (schema/optional-key :gzip-enable)                schema/Bool
    (schema/optional-key :access-log-config)          schema/Str
    (schema/optional-key :shutdown-timeout-seconds)   schema/Int
-   (schema/optional-key :post-config-script)         schema/Str})
+   (schema/optional-key :post-config-script)         schema/Str
+   (schema/optional-key :cache-session-id)           schema/Bool})
 
 (def MultiWebserverRawConfigUnvalidated
   {schema/Keyword  WebserverRawConfig})
@@ -178,7 +179,8 @@
    :client-auth                        WebserverSslClientAuth
    (schema/optional-key :ssl-crl-path) (schema/maybe schema/Str)
    :cipher-suites                      [schema/Str]
-   :protocols                          (schema/maybe [schema/Str])})
+   :protocols                          (schema/maybe [schema/Str])
+   :cache-session-id schema/Bool})
 
 (def WebserverSslConnector
   (merge
@@ -400,7 +402,8 @@
             :cipher-suites           (get-cipher-suites-config config)
             :protocols               (get-ssl-protocols-config config)
             :client-auth             (get-client-auth! config)
-            :ssl-crl-path            (get-ssl-crl-path! config)})))
+            :ssl-crl-path            (get-ssl-crl-path! config)
+            :cache-session-id (get config :cache-session-id true)})))
 
 (schema/defn ^:always-validate
   maybe-add-http-connector :- {(schema/optional-key :http) WebserverConnector

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -179,7 +179,7 @@
 (schema/defn ^:always-validate
   ssl-context-factory :- SslContextFactory
   "Creates a new SslContextFactory instance from a map of SSL config options."
-  [{:keys [keystore-config client-auth ssl-crl-path cipher-suites protocols]}
+  [{:keys [keystore-config client-auth ssl-crl-path cipher-suites protocols cache-session-id]}
    :- config/WebserverSslContextFactory]
   (if (some #(= "sslv3" %) (map str/lower-case protocols))
     (log/warn (str "`ssl-protocols` contains SSLv3, a protocol with known "
@@ -212,6 +212,7 @@
       ; order to force Jetty to actually use the CRL when validating client
       ; certificates for a connection.
       (.setValidatePeerCerts context true))
+    (.setSessionCachingEnabled context cache-session-id)
     context))
 
 (schema/defn ^:always-validate
@@ -222,7 +223,8 @@
                            ssl-config)
                         :client-auth :none
                         :cipher-suites (or (:cipher-suites ssl-config) config/acceptable-ciphers)
-                        :protocols     (or (:protocols ssl-config) config/default-protocols)}))
+                        :protocols     (or (:protocols ssl-config) config/default-protocols)
+                        :cache-session-id (get ssl-config :cache-session-id true)}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Jetty Server / Connector Functions
@@ -355,7 +357,8 @@
                                 :client-auth     (:client-auth https)
                                 :ssl-crl-path    (:ssl-crl-path https)
                                 :cipher-suites   (:cipher-suites https)
-                                :protocols       (:protocols https)})
+                                :protocols       (:protocols https)
+                                :cache-session-id (:cache-session-id https)})
             connector        (ssl-connector server ssl-ctxt-factory https)]
 
         (.addConnector server connector)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -64,7 +64,8 @@
       (update-in [:https :cipher-suites] (fnil identity acceptable-ciphers))
       (update-in [:https :protocols] (fnil identity default-protocols))
       (update-in [:https :client-auth] (fnil identity default-client-auth))
-      (update-in [:https :ssl-crl-path] identity)))
+      (update-in [:https :ssl-crl-path] identity)
+      (update-in [:https :cache-session-id] (fnil identity true))))
 
 (deftest process-config-http-test
   (testing "process-config successfully builds a WebserverConfig for plaintext connector"
@@ -216,7 +217,17 @@
            (munge-expected-https-config
              {:https {:host             "foo.local"
                       :port             8001
-                      :acceptor-threads 9193}})))))
+                      :acceptor-threads 9193}})))
+
+    (is (= (munge-actual-https-config
+             (merge valid-ssl-pem-config
+                    {:ssl-host "foo.local"
+                     :ssl-port 8001
+                     :cache-session-id false}))
+           (munge-expected-https-config
+             {:https {:host "foo.local"
+                      :port 8001
+                      :cache-session-id false}})))))
 
 (deftest process-config-jks-test
   (testing "jks ssl config"

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -231,6 +231,7 @@
       (update-in [:https :protocols] identity)
       (update-in [:https :cipher-suites] identity)
       (update-in [:https :client-auth] (fnil identity :none))
+      (update-in [:https :cache-session-id] (fnil identity true))
       (update-in [:https :keystore-config]
                  (fnil identity
                        {:truststore (-> (KeyStore/getDefaultType)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -8,6 +8,7 @@
            (appender TestListAppender))
   (:require [clojure.test :refer :all]
             [puppetlabs.http.client.async :as async]
+            [puppetlabs.http.client.sync :as sync]
             [puppetlabs.http.client.common :as http-client-common]
             [puppetlabs.kitchensink.testutils.fixtures :as ks-test-fixtures]
             [puppetlabs.trapperkeeper.app :as tk-app]
@@ -815,3 +816,26 @@
                                                                          {:ssl-protocols ["SSLv3"]}))]
          (is (= (:status response) 200))
          (is (= (:body response) "Hi World")))))))
+
+(deftest session-id-caching-test
+  (testing "ssl-caching is on by default"
+    (with-app-with-config
+      app
+      [jetty9-service
+       hello-webservice]
+      jetty-ssl-pem-config
+      (let [s (tk-app/get-service app :WebserverService)
+            state @(get-in (tk-services/service-context s) [:jetty9-servers :default :state])
+            ssl-ctxt (:ssl-context-factory state)]
+        (is (.isSessionCachingEnabled ssl-ctxt)))))
+
+  (testing "ssl-caching can be disabled"
+    (with-app-with-config
+      app
+      [jetty9-service
+       hello-webservice]
+      (assoc-in jetty-ssl-pem-config [:webserver :cache-session-id] false)
+      (let [s (tk-app/get-service app :WebserverService)
+            state @(get-in (tk-services/service-context s) [:jetty9-servers :default :state])
+            ssl-ctxt (:ssl-context-factory state)]
+        (is (not (.isSessionCachingEnabled ssl-ctxt)))))))


### PR DESCRIPTION
Add a new option, `:cache-session-id`, that defaults to true
and allows the caching of the SSL session id.