### PR TITLE
(TK-372) Reset MBeanContainer's map of bean names.

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -1,4 +1,5 @@
 (ns puppetlabs.trapperkeeper.services.webserver.jetty9-service
+  (:import (org.eclipse.jetty.jmx MBeanContainer))
   (:require
     [clojure.tools.logging :as log]
 
@@ -48,6 +49,8 @@
         (doseq [key (keys (:jetty9-servers context))]
           (if-let [server (key (:jetty9-servers context))]
             (core/shutdown server)))
+        ;; this class leaks MBean names if this method is not called
+        (MBeanContainer/resetUnique)
         context)
 
   (add-context-handler [this base-path context-path]


### PR DESCRIPTION
In the stop method of the WebserverService, clear the MBeanContainer
class's static map of bean name fragments, which it uses to ensure that
bean names are unique when a name is not specified as the bean is
registered. Without this change, this static map leaks these name
fragments unless JMX metrics are specifically disabled in the TK config.