### PR TITLE
(maint) Fix typos in config docs

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -451,7 +451,7 @@ webserver: {
 In this case, the Jetty9 Service will simply create a single webserver and give it id `:default`,
 and will automatically make this server the default server.
 
-### `jmx-enabled`
+### `jmx-enable`
 
 Optional. When enabled this setting will register the Jetty 9 MBeans so they are visible via
 JMX. Useful for monitoring the state of your Jetty 9 instance while it is running; for monitoring and

--- a/doc/webrouting-config.md
+++ b/doc/webrouting-config.md
@@ -84,5 +84,5 @@ Also note that, because the webrouting service is built on top of the
 webserver service, the webserver service will need to be included in your
 `bootstrap.cfg` file, and the webserver service will need to be configured in
 your trapperkeeper configuration files. Please see
-[Configuring the Webserver](doc/jetty-config.md) for more details.
+[Configuring the Webserver](jetty-config.md) for more details.
 


### PR DESCRIPTION
The setting in the map passed to the service is `jmx-enable` not `jmx-enabled` and I don't see anywhere were we do a translation from the past tense to the bare infinitive (+ the schema [WebserverRawConfig](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj#L118), + the [translation of string -> bool](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj#L443) both refer to it as `jmx-enable`) so I'm relatively confident, without standing up a tk-jetty9 app, that the config file/user facing docs should also be `jmx-enable`.

Also fixes a broken inbound link to the doc in question.