### PR TITLE
(MAINT) Remove explicit logback dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ notifications:
   email: false
 
 # workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost

--- a/project.clj
+++ b/project.clj
@@ -26,8 +26,6 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
 
-                 [ch.qos.logback/logback-access "1.1.3"]
-
                  [org.codehaus.janino/janino "2.7.8"]
 
                  [javax.servlet/javax.servlet-api "3.1.0"]


### PR DESCRIPTION
Logback is pulled in through trapperkeeper already and not needed or wanted
as an explicit dependency of tk-jetty9