### PR TITLE
Add uri-path to websocket adapter

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -103,7 +103,7 @@ msgid "Could not remove security providers; HTTPS may not work!"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
-msgid "webserver config overridden for key ''{0''"
+msgid "webserver config overridden for key ''{0}''"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -118,10 +118,6 @@ msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
 msgid "{0} could not close the connection"
-msgstr ""
-
-#: src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
-msgid "webserver config overridden for key ''{0}''"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj

--- a/src/puppetlabs/experimental/websockets/client.clj
+++ b/src/puppetlabs/experimental/websockets/client.clj
@@ -15,4 +15,6 @@
   (ssl? [this]
     "Returns a boolean indicating if the session was established by wss://")
   (peer-certs [this]
-    "Returns an array of X509Certs presented by the ssl peer, if any"))
+    "Returns an array of X509Certs presented by the ssl peer, if any")
+  (request-path [this]
+    "Returns the URI path used in the websocket upgrade request to the server"))


### PR DESCRIPTION
Adds uri-path to the WebsocketProtocol and implementation. This caches
the URI used in the upgrade request to establish a websocket connection
so we can retrieve it even after the session has closed. It also caches
the remote address for the same purpose.