### PR TITLE
(SERVER-1695) Expose a request-body-max-size webserver setting

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -70,6 +70,15 @@ queue is full would be seen by the client as having initially connected to the
 server socket at the TCP layer but having been closed almost immediately
 afterward by the server with no HTTP layer response body.
 
+### `request-body-max-size`
+
+This sets the maximum size, in bytes, of the body for an HTTP request. The size
+of the request body is determined from the value for the request's HTTP
+Content-Length header. If the Content-Length exceeds the configured value, Jetty
+will return an HTTP 413 Error response. If this setting is not configured and/or
+the request does not provide a Content-Length header, Jetty will pass the
+request through to underlying handlers (bypassing Content-Length evaluation).
+
 ### `request-header-max-size`
 
 This sets the maximum size of an HTTP Request Header. If a header is sent

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -98,6 +98,7 @@
    (schema/optional-key :max-threads)                schema/Int
    (schema/optional-key :queue-max-size)             schema/Int
    (schema/optional-key :request-header-max-size)    schema/Int
+   (schema/optional-key :request-body-max-size)      schema/Int
    (schema/optional-key :so-linger-seconds)          schema/Int
    (schema/optional-key :idle-timeout-milliseconds)  schema/Int
    (schema/optional-key :ssl-port)                   schema/Int


### PR DESCRIPTION
This commit exposes a new webserver setting, request-body-max-size,
which can be used to configure the maximum HTTP Content-Length that
the Jetty webserver will accept for an incoming request.  If the
limit is exceeded, the request fails with a 413 error.  If the
setting is not present in configuration or the Content-Length
header is not present in the request, the request will be passed through
to underlying handlers for evaluation.