### PR TITLE
(MAINT) Prep for 1.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.7.0
+
+This is a feature and bugfix release.
+
+* [SERVER-1695](https://tickets.puppetlabs.com/browse/SERVER-1695) Add an
+optional `request-body-max-size` setting for restricting the maximum
+`Content-Length` allowed for requests.
+* [TK-429](https://tickets.puppetlabs.com/browse/TK-429) Fix for the ability
+to gzip-encode response bodies when an access log is configured.
+
 ## 1.6.0
 
 This is a "feature" release.

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "9.2.10.v20150310")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.6.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.7.0-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
Update CHANGELOG.md and project.clj file for the 1.7.0 release.