### PR TITLE
(TK-369) Update jetty dependency to 9.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: clojure
 lein: 2.7.1
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 ## 2.0.0
 
-The is a major release
+This is a major release
 
 * [TK-369](https://tickets.puppetlabs.com/browse/TK-369) Move Jetty dependency to 9.4.1
+  Notably, this change drops Java 7 support as Jetty 9.3 and higher only
+  support Java 8 and higher. No public APIs have changed in this release.
+
+* The behavior of normalize-uri-path has changed slightly due to changes in
+  Jetty's URIUtil decodePath method. Specifically, overlong encodings change
+  their decoded value (but are still not traversable), and semicolons no longer
+  terminate URI processing, but only when ; is followed at some point by
+  another path segment beginning with /. For example, "/foo/bar;bar=chocolate/baz;baz=bim"
+  now decodes to "/foo/bar/baz" while before it decoded to "/foo/bar".
+  (https://github.com/eclipse/jetty.project/commit/7f62f2600b943b9aed0e4771891939bf61372c5a)
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+The is a major release
+
+* [TK-369](https://tickets.puppetlabs.com/browse/TK-369) Move Jetty dependency to 9.4.1
+
 ## 1.7.0
 
 This is a feature and bugfix release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ This is a major release
   support Java 8 and higher. No public APIs have changed in this release.
 
 * The behavior of normalize-uri-path has changed slightly due to changes in
-  Jetty's URIUtil decodePath method. Specifically, overlong encodings change
-  their decoded value (but are still not traversable), and semicolons no longer
-  terminate URI processing, but only when ; is followed at some point by
-  another path segment beginning with /. For example, "/foo/bar;bar=chocolate/baz;baz=bim"
-  now decodes to "/foo/bar/baz" while before it decoded to "/foo/bar".
+  Jetty's URIUtil decodePath method. Specifically, overlong encodings (which
+  are considered invalid UTF-8) change their decoded value (but are still not
+  traversable), and semicolons no longer terminate URI processing, but only
+  when ; is followed at some point by another path segment beginning with /.
+  For example, "/foo/bar;bar=chocolate/baz;baz=bim" now decodes to
+  "/foo/bar/baz" while before it decoded to "/foo/bar". If the request has
+  invalid % encoded UTF-8 characters, the path will be decoded as an ISO-8859-1
+  encoded string.
   (https://github.com/eclipse/jetty.project/commit/7f62f2600b943b9aed0e4771891939bf61372c5a)
 
 ## 1.7.0

--- a/README.md
+++ b/README.md
@@ -187,13 +187,20 @@ when the `:normalize-request-uri` setting is true:
   
   If a non-percent encoded semicolon character, U+003B, is found in the path
   during the percent decoding step, that character and all following characters
-  will be removed from the resulting path.
+  will be removed from the resulting path, unless there is another forward
+  slash, in which case the characters from the semicolon to the next forward
+  slash (including the semicolon) will be removed.
 
   For example:
 
   ```
   /foo//bar/%2E%2E/ba%7A;bim => /foo//bar/../baz
   ```
+
+  ```
+  /foo/bar;bar=chocolate/baz;baz=bim => /foo/bar/baz
+  ```
+
 
   Requests intending to include a semicolon in the path should percent-encode
   the semicolon.  In this case, the server will preserve the semicolon after the
@@ -207,6 +214,9 @@ when the `:normalize-request-uri` setting is true:
 
   If the request has malformed content, e.g., partially-formed percent-encoded
   characters like '%A%B', an HTTP 400 (Bad Request) error will be returned.
+
+  If the request has invalid % encoded UTF-8 characters, the path will be
+  decoded as an ISO-8859-1 encoded string.
 
 2. Check the percent-decoded path for any relative path segments ('..' or
    '.').

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -24,10 +24,13 @@ virtual cores on the host divided by 8, with a minimum of 1 and maximum of 4.
 
 ### `selector-threads`
 
-This sets the number of threads that the webserver will dedicate to processing
-events on connected sockets for _unencrypted_ HTTP traffic.  Defaults to the
-number of virtual cores on the host divided by 2, with a minimum of 1 and
-maximum of 4.
+This sets the number of selectors that the webserver will dedicate to
+processing events on connected sockets for unencrypted HTTPS traffic. Defaults
+to the number of virtual cores on the host divided by 2, with a minimum of 1
+and maximum of 4. The number of selector threads actually used by Jetty is
+twice the number of selectors requested. For example, if a value of 3 is
+specified for the `selector-threads` setting, Jetty will actually use 6
+selector threads.
 
 ### `max-threads`
 
@@ -126,10 +129,12 @@ virtual cores on the host divided by 8, with a minimum of 1 and maximum of 4.
 
 ### `ssl-selector-threads`
 
-This sets the number of threads that the webserver will dedicate to processing
-events on connected sockets for _encrypted_ HTTPS traffic.  Defaults to the
-number of virtual cores on the host divided by 2, with a minimum of 1 and
-maximum of 4. The number of selectors used by Jetty is twice the number of ssl
+This sets the number of selectors that the webserver will dedicate to
+processing events on connected sockets for encrypted HTTPS traffic. Defaults
+to the number of virtual cores on the host divided by 2, with a minimum of 1
+and maximum of 4. The number of selector threads actually used by Jetty is
+twice the number of selectors requested. For example, if a value of 3 is
+specified for the `ssl-selector-threads` setting, Jetty will actually use 6
 selector threads.
 
 ### `ssl-cert`

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -82,7 +82,7 @@ request through to underlying handlers (bypassing Content-Length evaluation).
 ### `request-header-max-size`
 
 This sets the maximum size of an HTTP Request Header. If a header is sent
-that exceeds this value, Jetty will return an HTTP 413 Error response. This
+that exceeds this value, Jetty will return an HTTP 431 Error response. This
 defaults to 8192 bytes, and only needs to be configured if an exceedingly large
 header is being sent in an HTTP Request.
 
@@ -129,7 +129,8 @@ virtual cores on the host divided by 8, with a minimum of 1 and maximum of 4.
 This sets the number of threads that the webserver will dedicate to processing
 events on connected sockets for _encrypted_ HTTPS traffic.  Defaults to the
 number of virtual cores on the host divided by 2, with a minimum of 1 and
-maximum of 4.
+maximum of 4. The number of selectors used by Jetty is twice the number of ssl
+selector threads.
 
 ### `ssl-cert`
 

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/LifeCycleImplementingRequestLogImpl.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/LifeCycleImplementingRequestLogImpl.java
@@ -1,0 +1,32 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
+
+import ch.qos.logback.access.jetty.RequestLogImpl;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+/*
+	Sit down, it's story time.
+	Once upon a time logback had a RequestLogImpl that you could just drop in
+	Jetty and use without any modifications. Developers used this and it was
+	good. Then, during Jetty 9.3 development, the RequestLog interface that
+	RequestLogImpl implemented was "refactored"[0] to no longer extend Jetty's
+	LifeCycle interface (this is distinct from Logback's LifeCycle interface,
+	so try to keep up).
+	Implementing Jetty's LifeCycle interface turns out to be important because
+	Jetty uses it to decide whether or not to automatically start a Bean[1].
+	Many people were sad about this[2] and tried to make the RequestLogImpl
+	again start automatically with Jetty[3], but their efforts have so far not
+	been merged.
+	In order for our RequestLogImpl to automatically start, we decide to extend
+	the existing built-in logback implementation and have it implement Jetty's
+	LifeCycle interface, which it already does, but doesn't declare.
+
+	[0] - https://github.com/eclipse/jetty.project/commit/e3bda4ef
+	[1] - https://github.com/eclipse/jetty.project/blob/0c8273f2ca1f9bf2064cd9c4c939d2546443f759/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java#L98
+	[2] - https://jira.qos.ch/browse/LOGBACK-1052
+	[3] - https://github.com/qos-ch/logback/pull/269
+
+	And Jetty and Logback lived happily ever after.
+
+ */
+
+public class LifeCycleImplementingRequestLogImpl extends RequestLogImpl implements LifeCycle {}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.2.10.v20150310")
+(def jetty-version "9.4.1.v20170120")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "2.0.0-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "9.2.10.v20150310")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "1.7.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-webserver-jetty9 "2.0.0-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -2,11 +2,11 @@
   (:import [java.security KeyStore]
            (java.io FileInputStream)
            (org.eclipse.jetty.server.handler RequestLogHandler)
-           (ch.qos.logback.access.jetty RequestLogImpl)
            (org.eclipse.jetty.server Server)
            (org.codehaus.janino ScriptEvaluator)
            (org.codehaus.commons.compiler CompileException)
-           (java.lang.reflect InvocationTargetException))
+           (java.lang.reflect InvocationTargetException)
+           (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils LifeCycleImplementingRequestLogImpl))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
@@ -444,11 +444,10 @@
   init-log-handler :- RequestLogHandler
   [config :- WebserverRawConfig]
   (let [handler (RequestLogHandler.)
-        logger (RequestLogImpl.)]
+        logger (LifeCycleImplementingRequestLogImpl.)]
     (.setFileName logger (:access-log-config config))
     (.setQuiet logger true)
     (.setRequestLog handler logger)
-    (.start logger)
     handler))
 
 (defn maybe-init-log-handler

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -448,6 +448,7 @@
     (.setFileName logger (:access-log-config config))
     (.setQuiet logger true)
     (.setRequestLog handler logger)
+    (.start logger)
     handler))
 
 (defn maybe-init-log-handler

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -705,7 +705,7 @@
          normalize-request-uri? (:normalize-request-uri? options)]
      (.setBaseResource handler (Resource/newResource base-path))
      (if follow-links?
-       (.addAliasCheck handler (AllowSymLinkAliasChecker.))
+       (.setAliasChecks handler [(AllowSymLinkAliasChecker.)])
        (.clearAliasChecks handler))
      ;; register servlet context listeners (if any)
      (when-not (nil? context-listeners)

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -315,7 +315,7 @@
         ;;
         ;; The QueuedThreadPool constructor sets the `queue-capacity` and
         ;; `queue-grow-by` based on the minimum number of threads available
-        ;; in the pool.  See https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L92-L96.
+        ;; in the pool.  See https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L101-L105.
         ;; That algorithm is essentially duplicated here, with the only
         ;; difference being that if `queue-max-size` is smaller than the
         ;; minimum number of threads, the `queue-capacity` and `queue-grow-by`
@@ -490,7 +490,7 @@
        (proxy-super sendProxyRequest req resp proxy-req))
 
       ;; The implementation of onResponseFailure is duplicated heavily from:
-      ;; https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L576-L607
+      ;; https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L624-L658
       ;; The only significant difference is that a 'failure-callback-fn', if
       ;; defined in options, is invoked just prior to completing the async
       ;; context for cases that the response was not already committed upstream.

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -3,22 +3,22 @@
                                      HttpConfiguration HttpConnectionFactory
                                      ConnectionFactory AbstractConnectionFactory)
            (org.eclipse.jetty.server.handler AbstractHandler ContextHandler HandlerCollection
-                                             ContextHandlerCollection AllowSymLinkAliasChecker StatisticsHandler HandlerWrapper)
+                                             ContextHandlerCollection AllowSymLinkAliasChecker
+                                             StatisticsHandler HandlerWrapper)
+           (org.eclipse.jetty.server.handler.gzip GzipHandler)
            (org.eclipse.jetty.util.resource Resource)
            (org.eclipse.jetty.util.thread QueuedThreadPool)
            (org.eclipse.jetty.util.ssl SslContextFactory)
            (javax.servlet.http HttpServletResponse)
            (java.util.concurrent TimeoutException)
-           (org.eclipse.jetty.servlets.gzip GzipHandler)
            (org.eclipse.jetty.servlet ServletContextHandler ServletHolder DefaultServlet)
            (org.eclipse.jetty.webapp WebAppContext)
-           (java.util HashSet)
            (org.eclipse.jetty.http MimeTypes HttpHeader HttpHeaderValue)
            (javax.servlet Servlet ServletContextListener)
            (org.eclipse.jetty.proxy ProxyServlet)
            (java.net URI)
            (java.security Security)
-           (org.eclipse.jetty.client HttpClient)
+           (org.eclipse.jetty.client HttpClient RedirectProtocolHandler)
            (clojure.lang Atom)
            (java.lang.management ManagementFactory)
            (org.eclipse.jetty.jmx MBeanContainer)
@@ -382,7 +382,7 @@
                  (.startsWith % "video/"))
             (MimeTypes/getKnownMimeTypes))
     (conj "application/compress" "application/zip" "application/gzip" "text/event-stream")
-    (HashSet.)))
+    (into-array)))
 
 (defn- gzip-handler
   "Given a handler, wrap it with a GzipHandler that will compress the response
@@ -390,8 +390,7 @@
   [handler]
   (doto (GzipHandler.)
     (.setHandler handler)
-    (.setMimeTypes (gzip-excluded-mime-types))
-    (.setExcludeMimeTypes true)))
+    (.setExcludedMimeTypes (gzip-excluded-mime-types))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Handler Helper Functions
@@ -437,7 +436,7 @@
                                     (:ssl-config options)))
         {:keys [request-buffer-size idle-timeout]} options]
     (proxy [ProxyServlet] []
-      (rewriteURI [req]
+      (rewriteTarget [req]
         (let [query (.getQueryString req)
               scheme (let [target-scheme (:scheme options)]
                        (condp = target-scheme
@@ -458,8 +457,8 @@
                                  (codec/url-decode (str query))
                                  nil)]
             (if-let [rewrite-uri-callback-fn (:rewrite-uri-callback-fn options)]
-              (rewrite-uri-callback-fn target-uri req)
-              target-uri))))
+              (str (rewrite-uri-callback-fn target-uri req))
+              (str target-uri)))))
 
       (newHttpClient []
         (let [client (if custom-ssl-ctxt-factory
@@ -477,22 +476,25 @@
               timeout (when idle-timeout
                         (* 1000 idle-timeout))]
           (if (:follow-redirects options)
-            (.setFollowRedirects client true)
+            (do
+              (.setFollowRedirects client true)
+              (.put (.getProtocolHandlers client) (RedirectProtocolHandler. client)))
             (.setFollowRedirects client false))
           (when timeout
             (.setIdleTimeout client timeout))
           client))
 
-      (customizeProxyRequest [proxy-req req]
+      (sendProxyRequest [req resp proxy-req]
         (if-let [callback-fn (:callback-fn options)]
-         (callback-fn proxy-req req)))
+         (callback-fn proxy-req req))
+       (proxy-super sendProxyRequest req resp proxy-req))
 
       ;; The implementation of onResponseFailure is duplicated heavily from:
       ;; https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L576-L607
       ;; The only significant difference is that a 'failure-callback-fn', if
       ;; defined in options, is invoked just prior to completing the async
       ;; context for cases that the response was not already committed upstream.
-      (onResponseFailure [req resp proxy-resp failure]
+      (onProxyResponseFailure [req resp proxy-resp failure]
         (do
           (let [request-id    (.getRequestId this req)
                 async-context (.getAsyncContext req)]
@@ -702,8 +704,9 @@
          enable-trailing-slash-redirect? (:enable-trailing-slash-redirect? options)
          normalize-request-uri? (:normalize-request-uri? options)]
      (.setBaseResource handler (Resource/newResource base-path))
-     (when follow-links?
-       (.addAliasCheck handler (AllowSymLinkAliasChecker.)))
+     (if follow-links?
+       (.addAliasCheck handler (AllowSymLinkAliasChecker.))
+       (.clearAliasChecks handler))
      ;; register servlet context listeners (if any)
      (when-not (nil? context-listeners)
        (dorun (map #(.addEventListener handler %) context-listeners)))

--- a/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
@@ -60,24 +60,24 @@
     (handle [^String target ^Request base-request
              ^HttpServletRequest request ^HttpServletResponse response]
       (when-let [handler (proxy-super getHandler)]
-          (if-let [normalized-uri
-                   (try
-                     (normalize-uri-path request)
-                     (catch IllegalArgumentException ex
-                       (do
-                         (servlet/update-servlet-response
-                          response
-                          {:status 400
-                           :body (.getMessage ex)})
-                         (.setHandled base-request true))
-                       nil))]
-            (.handle
-             handler
-             target
-             base-request
-             (HttpServletRequestWithAlternateRequestUri.
-              request
-              normalized-uri)
+        (if-let [normalized-uri
+                 (try
+                   (normalize-uri-path request)
+                   (catch IllegalArgumentException ex
+                     (do
+                       (servlet/update-servlet-response
+                        response
+                        {:status 400
+                         :body (.getMessage ex)})
+                       (.setHandled base-request true))
+                     nil))]
+          (.handle
+           handler
+           target
+           base-request
+           (HttpServletRequestWithAlternateRequestUri.
+            request
+            normalized-uri)
            response))))))
 
 (schema/defn ^:always-validate normalized-uri-filter :- Filter

--- a/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
@@ -59,14 +59,8 @@
   (proxy [HandlerWrapper] []
     (handle [^String target ^Request base-request
              ^HttpServletRequest request ^HttpServletResponse response]
-      (let [handler (proxy-super getHandler)
-            is-started (proxy-super isStarted)]
-        ;; It may not strictly be necessary to check if the wrapping handler
-        ;; is started in order to let a request through but that's what the
-        ;; base `HandlerWrapper` class from Jetty does, so it seemed best to
-        ;; follow the pattern:
-        ;; https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandlerWrapper.java#L95
-        (when (and handler is-started)
+      (let [handler (proxy-super getHandler)]
+        (when handler
           (if-let [normalized-uri
                    (try
                      (normalize-uri-path request)

--- a/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
@@ -59,8 +59,7 @@
   (proxy [HandlerWrapper] []
     (handle [^String target ^Request base-request
              ^HttpServletRequest request ^HttpServletResponse response]
-      (let [handler (proxy-super getHandler)]
-        (when handler
+      (when-let [handler (proxy-super getHandler)]
           (if-let [normalized-uri
                    (try
                      (normalize-uri-path request)
@@ -79,7 +78,7 @@
              (HttpServletRequestWithAlternateRequestUri.
               request
               normalized-uri)
-             response)))))))
+           response))))))
 
 (schema/defn ^:always-validate normalized-uri-filter :- Filter
   "Create a servlet filter which provides a normalized request URI on to its

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_default_config_test.clj
@@ -56,7 +56,7 @@ react accordingly."
 
 (deftest default-request-header-max-size-test
   (let [http-config (HttpConfiguration.)]
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L49
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L55
     (is (= 8192 (.getRequestHeaderSize http-config))
         "Unexpected default for 'request-header-max-size'")))
 
@@ -80,10 +80,10 @@ react accordingly."
                           true
                           false)
           client        (.createHttpClient proxy-servlet)]
-      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java#L129
+      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java#L135
       (is (= 4096 (.getRequestBufferSize client))
           "Unexpected default for proxy 'request-buffer-size'")
-      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L268-L271
+      ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java#L304-L307
       (is (= 30000 (.getIdleTimeout client))
           "Unexpected default for proxy 'idle-timeout'")
       (.stop client))))
@@ -98,15 +98,15 @@ react accordingly."
 
 (def acceptor-thread-count
   "The number of acceptor threads that should be allocated per connector.  See:
-   https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L190"
+   https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L194"
   (max 1 (min 4 (int (/ (ks/num-cpus) 8)))))
 
 (deftest default-connector-settings-test
   (let [connector (ServerConnector. (Server.))]
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L85
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java#L87
     (is (= -1 (.getSoLingerTime connector))
         "Unexpected default for 'so-linger-seconds'")
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L146
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java#L150
     (is (= 30000 (.getIdleTimeout connector))
         "Unexpected default for 'idle-timeout-milliseconds'")
     (is (= acceptor-thread-count (.getAcceptors connector))
@@ -132,13 +132,13 @@ react accordingly."
 
 (deftest default-server-settings-test
   (let [server (Server.)]
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java#L48
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java#L48
     (is (= 30000 (.getStopTimeout server))
         "Unexpected default for 'shutdown-timeout-seconds'")
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L67
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L71
     (is (= 200 (get-max-threads-for-server server))
         "Unexpected default for 'max-threads'")
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java#L117
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java#L92
     (is (= (Integer/MAX_VALUE) (.getMaxCapacity
                                  (get-server-thread-pool-queue server)))
         "Unexpected default for 'queue-max-size'")))
@@ -149,7 +149,7 @@ react accordingly."
 
 (defn calculate-minimum-required-threads
   "Calculate the minimum number threads that a single Jetty Server instance
-  needs.  See: https://github.com/eclipse/jetty.project/blob/jetty-9.2.10.v20150310/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L334-L350"
+  needs.  See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L384-L414"
   [connectors]
   (+ 1 (* connectors threads-per-connector)))
 

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
@@ -598,16 +598,16 @@
                       :path "/hello"}
        :proxy-opts   {:follow-redirects true}
        :ring-handler redirect-test-handler}
-      (let [response (http-get (str "http://localhost:9000/hello/"))]
+      (let [response (http-get "http://localhost:9000/hello/")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:9000/hello/world"))]
+      (let [response (http-get "http://localhost:9000/hello/world")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:10000/hello-proxy"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:10000/hello-proxy/world"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy/world")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))))
 
@@ -621,7 +621,7 @@
                       :port 9000
                       :path "/hello"}
        :ring-handler redirect-test-handler}
-      (let [response (http-get (str "http://localhost:10000/hello-proxy"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy")]
         (is (= (:status response) 404)))))
 
   (testing "proxy-redirect to non-target host fails"
@@ -635,7 +635,7 @@
                       :path "/hello"}
        :proxy-opts   {:follow-redirects true}
        :ring-handler redirect-wrong-host}
-      (let [response (http-get (str "http://localhost:10000/hello-proxy"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy")]
         (is (= (:status response) 502)))))
 
   (testing "proxy redirect to correct host in fully qualified url works"
@@ -649,16 +649,16 @@
                       :path "/hello"}
        :proxy-opts   {:follow-redirects true}
        :ring-handler redirect-same-host}
-      (let [response (http-get (str "http://localhost:9000/hello/"))]
+      (let [response (http-get "http://localhost:9000/hello/")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:9000/hello/world"))]
+      (let [response (http-get "http://localhost:9000/hello/world")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:10000/hello-proxy"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:10000/hello-proxy/world"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy/world")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))))
 
@@ -673,10 +673,10 @@
                       :path "/hello"}
        :proxy-opts   {:follow-redirects true}
        :ring-handler redirect-different-proxy-path}
-      (let [response (http-get (str "http://localhost:9000/hello/"))]
+      (let [response (http-get "http://localhost:9000/hello/")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!")))
-      (let [response (http-get (str "http://localhost:10000/hello-proxy"))]
+      (let [response (http-get "http://localhost:10000/hello-proxy")]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello, World!"))))))
 

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -5,7 +5,8 @@
            (java.net BindException)
            (java.nio.file Paths Files)
            (java.nio.file.attribute FileAttribute)
-           (appender TestListAppender))
+           (appender TestListAppender)
+           (javax.net.ssl SSLException))
   (:require [clojure.test :refer :all]
             [puppetlabs.http.client.async :as async]
             [puppetlabs.http.client.common :as http-client-common]
@@ -68,6 +69,8 @@
     ~@body
     (throw (IllegalStateException. "Expected SSL Exception to be thrown!"))
     (catch ConnectionClosedException e#
+      true)
+    (catch SSLException e#
       true)
     (catch IOException e#
       (if (= "Connection reset by peer" (.getMessage e#))
@@ -529,7 +532,8 @@
       (tk-app/stop app))))
 
 (deftest large-request-test
-  (testing (str "request to Jetty fails with a 413 error if the request header "
+  ;; This changed from 413 to 431 in https://github.com/eclipse/jetty.project/commit/e53ea55f480a959a2f1f5e2dbdbfc689d61c94a6
+  (testing (str "request to Jetty fails with a 431 error if the request header "
                 "is too large and a larger one is not set")
     (with-app-with-config app
       [jetty9-service
@@ -538,7 +542,7 @@
       (tk-log-testutils/with-test-logging
        (let [response (http-get "http://localhost:8080/hi_world" {:headers {"Cookie" absurdly-large-cookie}
                                                                   :as :text})]
-         (is (= (:status response) 413))))))
+         (is (= (:status response) 431))))))
 
   (testing (str "request to Jetty succeeds with a large cookie if the request header "
                 "size is properly set")
@@ -804,7 +808,7 @@
        hello-webservice]
       jetty-ssl-pem-config
       (is (thrown?
-           ConnectionClosedException
+           SSLException
            (http-get "https://localhost:8081/hi_world" (merge default-options-for-https-client
                                                               {:ssl-protocols ["SSLv3"]}))))))
   (testing "SSLv3 is supported when configured"

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -723,7 +723,11 @@
            (let [response (http-client-common/get async-client "http://localhost:8080/hello" {:as :text})]
              @in-request-handler
              (tk-app/stop app)
-             (is (not (nil? (:error @response))))))))))
+             (let [resp @response]
+               (is (or
+                    (not (nil? (:error resp)))
+                    (= 404 (:status resp)))
+                   resp))))))))
 
   (testing "tk app can still restart even if stop timeout expires"
     (let [in-request-handler? (promise)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -96,19 +96,19 @@
 
 (defn validate-ring-handler
   ([base-url config]
-    (validate-ring-handler base-url config {:as :text} :default))
+   (validate-ring-handler base-url config {:as :text} :default))
   ([base-url config http-get-options]
    (validate-ring-handler base-url config http-get-options :default))
   ([base-url config http-get-options server-id]
-    (with-app-with-config app
-      [jetty9-service
-       hello-webservice]
-      config
-      (let [response (http-get
-                      (format "%s%s/" base-url hello-path)
-                      http-get-options)]
-        (is (= (:status response) 200))
-        (is (= (:body response) hello-body))))))
+   (with-app-with-config app
+     [jetty9-service
+      hello-webservice]
+     config
+     (let [response (http-get
+                     (format "%s%s/" base-url hello-path)
+                     http-get-options)]
+       (is (= (:status response) 200))
+       (is (= (:body response) hello-body))))))
 
 (defn validate-ring-handler-default
   ([base-url config]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -716,7 +716,7 @@
              in-request-handler (promise)
              ring-handler (fn [_]
                             (deliver in-request-handler true)
-                            (Thread/sleep 300)
+                            (Thread/sleep 2000)
                             {:status 200 :body "Hello, World!"})]
          (add-ring-handler ring-handler "/hello")
          (with-open [async-client (async/create-client {})]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers_test.clj
@@ -33,7 +33,7 @@
   (testing (str "non-percent encoded parameters in uri path segments are "
                 "chopped off after normalization")
     (is (= "/foo" (normalize-uri-path-for-string "/foo;foo=chump")))
-    (is (= "/foo/bar" (normalize-uri-path-for-string
+    (is (= "/foo/bar/baz" (normalize-uri-path-for-string
                        "/foo/bar;bar=chocolate/baz;baz=bim"))))
   (testing (str "percent-encoded parameters in uri path segments are properly "
                 "decoded after normalization")
@@ -116,8 +116,8 @@
     ;;> or the surrogate pair ED A1 8C ED BE B4 into U+233B4.  Decoding
     ;;> invalid sequences may have security consequences or cause other
     ;;> problems.
-    (is (= "��" (normalize-uri-path-for-string "%C0%AE")))
-    (is (= "/foo/��/��" (normalize-uri-path-for-string "/foo/%C0%AE/%C0%AE")))))
+    (is (= "-64-82" (normalize-uri-path-for-string "%C0%AE")))
+    (is (= "/foo/-64-82/-64-82" (normalize-uri-path-for-string "/foo/%C0%AE/%C0%AE")))))
 
 (deftest normalize-uris-with-redundant-slashes-tests
   (testing "uris with redundant slashes are removed"

--- a/test/java/appender/TestListAppender.java
+++ b/test/java/appender/TestListAppender.java
@@ -4,7 +4,6 @@ import ch.qos.logback.access.PatternLayout;
 import ch.qos.logback.access.PatternLayoutEncoder;
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.AppenderBase;
-import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.encoder.Encoder;
 
 import java.util.ArrayList;


### PR DESCRIPTION
This commit updates jetty to 9.4.1, which requires several changes to
tests and the config and core namespaces. Here are a list of changes and
why they were made:

Code changes

* Manually start the request logger when set
  This change
    eclipse/jetty.project@34a8da2
  seems to have caused logging to no longer work without starting here.
  Starting after the server was started did not do the right thing.

* GzipHandler changes
  GzipHandler moved into a new package, into jetty-server from
  jetty-servlets and some of the setup methods changed, notably
  around excluding mime types.

* ProxyServlet changes
  Several methods in the ProxyServlet and AbstractProxyServlet were
  deprecated, so the methods being proxied also have been updated.

* Enable client redirects
  The http connection used for proxies began clearing all handlers in
  eclipse/jetty.project@c7cff6e#diff-571b48f4ff5fbf0a57c41ad7c7ac5dedR297
  so we must manually add the redirect handler back on to correctly
  handle 302s

* Disable symlinks
  In eclipse/jetty.project@d8e6331,
  symlink aliases were allowed by default on all unix platforms, so we
  clear aliases when follow-symlinks is false.

Test changes

* 431 now returned for headers that are too long instead of 413

* SSLException thrown instead of ConnectException for some errors

* URIUtil decodePath changes
  decodePath was changed during a refactor. Path traversal is still
  protected against, but the characters returned have changed, and
  additionally semicolons no longer terminate parsing.