### PR TITLE
(TK-149) Reload the crl file in the running webservers on change

### DIFF
--- a/examples/ring_app/bootstrap.cfg
+++ b/examples/ring_app/bootstrap.cfg
@@ -1,5 +1,6 @@
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
 examples.ring-app.example-services/count-service
 examples.ring-app.example-services/bert-service
 examples.ring-app.example-services/ernie-service

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -1,0 +1,166 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
+
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.security.CertificateUtils;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.cert.CRL;
+import java.util.Collection;
+
+public class InternalSslContextFactory extends SslContextFactory {
+
+    private static int maxTries = 5;
+    private static int sleepInMillisecondsBetweenTries = 1000;
+    private static final Logger LOG =
+            Log.getLogger(InternalSslContextFactory.class);
+
+    private Collection<? extends CRL> _crls;
+
+    @Override
+    protected void checkNotStarted() {
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        synchronized (this) {
+            load();
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        synchronized (this) {
+            unload();
+        }
+        super.doStop();
+    }
+
+    @Override
+    protected Collection<? extends CRL> loadCRL(String crlPath) throws Exception {
+        Collection<? extends CRL> crls;
+
+        synchronized (this) {
+            if (_crls == null) {
+                crls = super.loadCRL(crlPath);
+            } else {
+                crls = _crls;
+            }
+        }
+
+        return crls;
+    }
+
+    private void load() throws Exception {
+        synchronized (this) {
+            super.doStart();
+        }
+    }
+
+    private void unload() throws Exception {
+        synchronized (this) {
+            super.doStop();
+        }
+    }
+
+    @Override
+    public SSLContext getSslContext() {
+        synchronized (this) {
+            return super.getSslContext();
+        }
+    }
+
+    @Override
+    public SSLServerSocket newSslServerSocket(String host,
+                                              int port,
+                                              int backlog)
+            throws IOException {
+        synchronized (this) {
+            return super.newSslServerSocket(host, port, backlog);
+        }
+    }
+
+    @Override
+    public SSLSocket newSslSocket() throws IOException {
+        synchronized (this) {
+            return super.newSslSocket();
+        }
+    }
+
+    @Override
+    public SSLEngine newSSLEngine() {
+        synchronized (this) {
+            return super.newSSLEngine();
+        }
+    }
+
+    @Override
+    public SSLEngine newSSLEngine(String host, int port) {
+        synchronized (this) {
+            return super.newSSLEngine(host, port);
+        }
+    }
+
+    @Override
+    public SSLEngine newSSLEngine(InetSocketAddress address) {
+        synchronized (this) {
+            return super.newSSLEngine(address);
+        }
+    }
+
+    public void reload() throws Exception {
+        synchronized (this) {
+            Exception reloadEx;
+            int tries = maxTries;
+            String crlPath = getCrlPath();
+            File crlPathAsFile = null;
+            long crlLastModified = 0;
+
+            if (crlPath != null) {
+                crlPathAsFile = new File(crlPath);
+                crlLastModified = crlPathAsFile.lastModified();
+            }
+
+            // Try to parse CRLs from the crlPath until it is successful
+            // or a hard-coded number of failed attempts have been made.
+            do {
+                reloadEx = null;
+                try {
+                    _crls = CertificateUtils.loadCRL(crlPath);
+                } catch (Exception e) {
+                    reloadEx = e;
+
+                    // If the CRL file has been updated since the last reload
+                    // attempt, reset the retry counter.
+                    if (crlPathAsFile != null &&
+                            crlLastModified != crlPathAsFile.lastModified()) {
+                        crlLastModified = crlPathAsFile.lastModified();
+                        tries = maxTries;
+                    } else {
+                        tries--;
+                    }
+
+                    if (tries == 0) {
+                        LOG.warn("Failed ssl context reload after " +
+                                maxTries + " tries.  CRL file is: " +
+                                crlPath, reloadEx);
+                    } else {
+                        Thread.sleep(sleepInMillisecondsBetweenTries);
+                    }
+                }
+            } while (reloadEx != null && tries > 0);
+
+            if (reloadEx == null) {
+                unload();
+                load();
+            }
+        }
+    }
+}

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -17,8 +17,8 @@ import java.util.Collection;
 
 public class InternalSslContextFactory extends SslContextFactory {
 
-    private static int maxTries = 5;
-    private static int sleepInMillisecondsBetweenTries = 1000;
+    private static int maxTries = 25;
+    private static int sleepInMillisecondsBetweenTries = 100;
     private static final Logger LOG =
             Log.getLogger(InternalSslContextFactory.class);
 

--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/i18n]
+                 [puppetlabs/trapperkeeper-filesystem-watcher]
                  ]
 
   :source-paths  ["src"]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -408,22 +408,22 @@
        (Thread/sleep 1000)
        (fs/copy "./dev-resources/config/jetty/ssl/crls/crls_localhost_revoked.pem"
                 tmp-file)
-       (loop [times 30]
-         (cond
-           (try
-             (ssl-exception-thrown? (get-request))
-             (catch IllegalStateException _
-               false))
-           (is true)
+       (is
+        (loop [times 30]
+          (cond
+            (try
+              (ssl-exception-thrown? (get-request))
+              (catch IllegalStateException _
+                false))
+            true
 
-           (zero? times)
-           (is (ssl-exception-thrown? (get-request))
-               "localhost cert was not revoked")
+            (zero? times)
+            (ssl-exception-thrown? (get-request))
 
-           :else
-           (do
-             (Thread/sleep 500)
-             (recur (dec times)))))))))
+            :else
+            (do
+              (Thread/sleep 500)
+              (recur (dec times))))))))))
 
 (defn boot-service-and-jetty-with-default-config
   [service]

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -15,6 +15,8 @@
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service
              :refer :all]
+            [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service
+             :as filesystem-watch-service]
             [puppetlabs.trapperkeeper.testutils.webserver :as testutils]
             [puppetlabs.trapperkeeper.testutils.webserver.common :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap
@@ -25,7 +27,9 @@
             [puppetlabs.trapperkeeper.testutils.logging :as tk-log-testutils]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as core]
             [schema.core :as schema]
-            [schema.test :as schema-test]))
+            [schema.test :as schema-test]
+            [puppetlabs.kitchensink.core :as ks]
+            [me.raynes.fs :as fs]))
 
 (use-fixtures :once
   ks-test-fixtures/with-no-jvm-shutdown-hooks
@@ -371,6 +375,55 @@
                 jetty-ssl-client-need-config
                 [:webserver :ssl-crl-path]
                 "./dev-resources/config/jetty/ssl/crls/crls_bogus.pem")))))))
+
+(deftest crl-reloaded-without-server-restart-test
+  (let [tmp-dir (ks/temp-dir)
+        tmp-file (fs/file tmp-dir "mycrl.pem")
+        get-request #(http-get
+                      (str "https://localhost:8081" hello-path)
+                      default-options-for-https-client)]
+    (fs/copy "./dev-resources/config/jetty/ssl/crls/crls_none_revoked.pem"
+             tmp-file)
+    (with-app-with-config
+     app
+     [jetty9-service
+      hello-webservice
+      filesystem-watch-service/filesystem-watch-service]
+
+     (assoc-in
+      jetty-ssl-client-need-config
+      [:webserver :ssl-crl-path]
+      (str tmp-file))
+
+     (testing "request to jetty successful before cert revoked"
+       (let [response (get-request)]
+         (is (= (:status response) 200))
+         (is (= (:body response) hello-body))))
+
+     (testing "request fails after cert revoked"
+       ;; Sleep a bit to wait for the file watcher to be ready to poll/notify
+       ;; for change events on the CRL. Ideally wouldn't have to do this but
+       ;; seems like the initial event notification doesn't propagate if the
+       ;; file is changed too soon after initialization.
+       (Thread/sleep 1000)
+       (fs/copy "./dev-resources/config/jetty/ssl/crls/crls_localhost_revoked.pem"
+                tmp-file)
+       (loop [times 30]
+         (cond
+           (try
+             (ssl-exception-thrown? (get-request))
+             (catch IllegalStateException _
+               false))
+           (is true)
+
+           (zero? times)
+           (is (ssl-exception-thrown? (get-request))
+               "localhost cert was not revoked")
+
+           :else
+           (do
+             (Thread/sleep 500)
+             (recur (dec times)))))))))
 
 (defn boot-service-and-jetty-with-default-config
   [service]


### PR DESCRIPTION
This commit uses the tk-filesystem-watcher service to register a change
notification for the CRL file given to the Jetty webserver.  On
detection of a change, the Jetty SSLContextFactory is reloaded.  This
allows for the updated CRL file to be used without requiring a full
webserver restart.  Runtime CRL updating now occurs when tk-jetty9 is
used in a webservice stack which includes the optional
tk-filesystem-watcher dependency.