### PR TITLE
(TK-149) Reload the crl file in the running webservers on change

### DIFF
--- a/examples/ring_app/bootstrap.cfg
+++ b/examples/ring_app/bootstrap.cfg
@@ -1,5 +1,6 @@
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
 examples.ring-app.example-services/count-service
 examples.ring-app.example-services/bert-service
 examples.ring-app.example-services/ernie-service

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -12,8 +12,8 @@ import java.util.function.Consumer;
 
 public class InternalSslContextFactory extends SslContextFactory {
 
-    private static int maxTries = 5;
-    private static int sleepInMillisecondsBetweenTries = 1000;
+    private static int maxTries = 25;
+    private static int sleepInMillisecondsBetweenTries = 100;
     private static final Logger LOG =
             Log.getLogger(InternalSslContextFactory.class);
     private static Consumer<SslContextFactory> consumer = sslContextFactory

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -1,0 +1,86 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
+
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.security.CertificateUtils;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import java.io.File;
+import java.security.cert.CRL;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+public class InternalSslContextFactory extends SslContextFactory {
+
+    private static int maxTries = 5;
+    private static int sleepInMillisecondsBetweenTries = 1000;
+    private static final Logger LOG =
+            Log.getLogger(InternalSslContextFactory.class);
+    private static Consumer<SslContextFactory> consumer = sslContextFactory
+            -> {};
+
+    private Collection<? extends CRL> _crls;
+
+    @Override
+    protected Collection<? extends CRL> loadCRL(String crlPath) throws Exception {
+        Collection<? extends CRL> crls;
+
+        synchronized (this) {
+            if (_crls == null) {
+                crls = super.loadCRL(crlPath);
+            } else {
+                crls = _crls;
+            }
+        }
+
+        return crls;
+    }
+
+    public void reload() throws Exception {
+        synchronized (this) {
+            Exception reloadEx;
+            int tries = maxTries;
+            String crlPath = getCrlPath();
+            File crlPathAsFile = null;
+            long crlLastModified = 0;
+
+            if (crlPath != null) {
+                crlPathAsFile = new File(crlPath);
+                crlLastModified = crlPathAsFile.lastModified();
+            }
+
+            // Try to parse CRLs from the crlPath until it is successful
+            // or a hard-coded number of failed attempts have been made.
+            do {
+                reloadEx = null;
+                try {
+                    _crls = CertificateUtils.loadCRL(crlPath);
+                } catch (Exception e) {
+                    reloadEx = e;
+
+                    // If the CRL file has been updated since the last reload
+                    // attempt, reset the retry counter.
+                    if (crlPathAsFile != null &&
+                            crlLastModified != crlPathAsFile.lastModified()) {
+                        crlLastModified = crlPathAsFile.lastModified();
+                        tries = maxTries;
+                    } else {
+                        tries--;
+                    }
+
+                    if (tries == 0) {
+                        LOG.warn("Failed ssl context reload after " +
+                                maxTries + " tries.  CRL file is: " +
+                                crlPath, reloadEx);
+                    } else {
+                        Thread.sleep(sleepInMillisecondsBetweenTries);
+                    }
+                }
+            } while (reloadEx != null && tries > 0);
+
+            if (reloadEx == null) {
+                reload(consumer);
+            }
+        }
+    }
+}

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -38,45 +38,43 @@ public class InternalSslContextFactory extends SslContextFactory {
 
     public void reload() throws Exception {
         synchronized (this) {
-            Exception reloadEx;
+            Exception reloadEx = null;
             int tries = maxTries;
             String crlPath = getCrlPath();
-            File crlPathAsFile = null;
-            long crlLastModified = 0;
 
             if (crlPath != null) {
-                crlPathAsFile = new File(crlPath);
-                crlLastModified = crlPathAsFile.lastModified();
+                File crlPathAsFile = new File(crlPath);
+                long crlLastModified = crlPathAsFile.lastModified();
+
+                // Try to parse CRLs from the crlPath until it is successful
+                // or a hard-coded number of failed attempts have been made.
+                do {
+                    reloadEx = null;
+                    try {
+                        _crls = CertificateUtils.loadCRL(crlPath);
+                    } catch (Exception e) {
+                        reloadEx = e;
+
+                        // If the CRL file has been updated since the last reload
+                        // attempt, reset the retry counter.
+                        if (crlPathAsFile != null &&
+                                crlLastModified != crlPathAsFile.lastModified()) {
+                            crlLastModified = crlPathAsFile.lastModified();
+                            tries = maxTries;
+                        } else {
+                            tries--;
+                        }
+
+                        if (tries == 0) {
+                            LOG.warn("Failed ssl context reload after " +
+                                    maxTries + " tries.  CRL file is: " +
+                                    crlPath, reloadEx);
+                        } else {
+                            Thread.sleep(sleepInMillisecondsBetweenTries);
+                        }
+                    }
+                } while (reloadEx != null && tries > 0);
             }
-
-            // Try to parse CRLs from the crlPath until it is successful
-            // or a hard-coded number of failed attempts have been made.
-            do {
-                reloadEx = null;
-                try {
-                    _crls = CertificateUtils.loadCRL(crlPath);
-                } catch (Exception e) {
-                    reloadEx = e;
-
-                    // If the CRL file has been updated since the last reload
-                    // attempt, reset the retry counter.
-                    if (crlPathAsFile != null &&
-                            crlLastModified != crlPathAsFile.lastModified()) {
-                        crlLastModified = crlPathAsFile.lastModified();
-                        tries = maxTries;
-                    } else {
-                        tries--;
-                    }
-
-                    if (tries == 0) {
-                        LOG.warn("Failed ssl context reload after " +
-                                maxTries + " tries.  CRL file is: " +
-                                crlPath, reloadEx);
-                    } else {
-                        Thread.sleep(sleepInMillisecondsBetweenTries);
-                    }
-                }
-            } while (reloadEx != null && tries > 0);
 
             if (reloadEx == null) {
                 reload(consumer);

--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/i18n]
+                 [puppetlabs/trapperkeeper-filesystem-watcher]
                  ]
 
   :source-paths  ["src"]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -23,7 +23,8 @@
            (java.lang.management ManagementFactory)
            (org.eclipse.jetty.jmx MBeanContainer)
            (org.eclipse.jetty.util URIUtil BlockingArrayQueue)
-           (java.io IOException))
+           (java.io IOException File)
+           (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils InternalSslContextFactory))
 
   (:require [ring.util.servlet :as servlet]
             [ring.util.codec :as codec]
@@ -33,8 +34,11 @@
             [puppetlabs.trapperkeeper.services.webserver.experimental.jetty9-websockets :as websockets]
             [puppetlabs.trapperkeeper.services.webserver.normalized-uri-helpers
              :as normalized-uri-helpers]
+            [puppetlabs.trapperkeeper.services.protocols.filesystem-watch-service
+             :as watch-protocol]
             [schema.core :as schema]
-            [puppetlabs.i18n.core :as i18n]))
+            [puppetlabs.i18n.core :as i18n]
+            [me.raynes.fs :as fs]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; JDK SecurityProvider Hack
@@ -137,7 +141,7 @@
    :overrides-read-by-webserver schema/Bool
    :overrides (schema/maybe {schema/Keyword schema/Any})
    :endpoints RegisteredEndpoints
-   :ssl-context-factory (schema/maybe SslContextFactory)})
+   :ssl-context-factory (schema/maybe InternalSslContextFactory)})
 
 (def ServerContext
   {:state     (schema/atom ServerContextState)
@@ -188,7 +192,7 @@
   (if (some #(= "sslv3" %) (map str/lower-case protocols))
     (log/warn (i18n/trs "`ssl-protocols` contains SSLv3, a protocol with known vulnerabilities; we recommend removing it from the `ssl-protocols` list")))
 
-  (let [context (doto (SslContextFactory.)
+  (let [context (doto (InternalSslContextFactory.)
                   (.setKeyStore (:keystore keystore-config))
                   (.setKeyStorePassword (:key-password keystore-config))
                   (.setTrustStore (:truststore keystore-config))
@@ -954,6 +958,25 @@
   (assoc context :jetty9-servers (into {} (for [[server-id] config]
                                             [server-id (initialize-context)]))
                  :default-server (get-default-server-from-config config)))
+
+(schema/defn ^:always-validate reload-crl-on-change!
+  "Reload the CRL file used by the supplied ssl-context-factory whenever any
+  changes to the file occur."
+  [ssl-context-factory :- InternalSslContextFactory
+   watcher :- (schema/protocol watch-protocol/Watcher)]
+  (when-let [crl-path (.getCrlPath ssl-context-factory)]
+    (let [normalized-crl-path (.getCanonicalPath (fs/file crl-path))]
+      (watch-protocol/add-watch-dir! watcher (fs/parent crl-path)
+                                     {:recursive true})
+      (watch-protocol/add-callback!
+       watcher
+       (fn [events]
+         (when (some #(and
+                       (:changed-path %)
+                       (= (.getCanonicalPath (:changed-path %))
+                          normalized-crl-path))
+                     events)
+           (.reload ssl-context-factory)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Service Function Implementations

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -411,22 +411,22 @@
        (Thread/sleep 1000)
        (fs/copy "./dev-resources/config/jetty/ssl/crls/crls_localhost_revoked.pem"
                 tmp-file)
-       (loop [times 30]
-         (cond
-           (try
-             (ssl-exception-thrown? (get-request))
-             (catch IllegalStateException _
-               false))
-           (is true)
+      (is
+        (loop [times 30]
+          (cond
+            (try
+              (ssl-exception-thrown? (get-request))
+              (catch IllegalStateException _
+                false))
+            true
 
-           (zero? times)
-           (is (ssl-exception-thrown? (get-request))
-               "localhost cert was not revoked")
+            (zero? times)
+            (ssl-exception-thrown? (get-request))
 
-           :else
-           (do
-             (Thread/sleep 500)
-             (recur (dec times)))))))))
+            :else
+            (do
+              (Thread/sleep 500)
+              (recur (dec times))))))))))
 
 (defn boot-service-and-jetty-with-default-config
   [service]


### PR DESCRIPTION
This commit uses the tk-filesystem-watcher service to register a change
notification for the CRL file given to the Jetty webserver.  On
detection of a change, the Jetty SSLContextFactory is reloaded.  This
allows for the updated CRL file to be used without requiring a full
webserver restart.  Runtime CRL updating now occurs when tk-jetty9 is
used in a webservice stack which includes the optional
tk-filesystem-watcher dependency.