### PR TITLE
(TK-449) Remove invalid cipher suite

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -234,7 +234,6 @@ you'll need to use the all-caps cipher suite name.
 
 If not supplied, trapperkeeper uses this list of cipher suites:
 
-- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
 - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -53,8 +53,7 @@
 ;;; risky for our downstream apps, thus it was decided that it makes sense to
 ;;; keep these overrides.
 (def acceptable-ciphers
-  ["TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA256"
-   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+  ["TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
 


### PR DESCRIPTION
Previously we included an invalid cipher suite in our list of cipher
suites to register.

This causes a warning to be logged at start up.

This patch removes the invalid cipher suite from the list of cipher
suites we register.