### PR TITLE
(TK-448) use non-recursive form of watch service watcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ lein: 2.7.1
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.8.1
+
+This is a bugfix release.
+
+* [TK-448](https:/tickets.puppet.com/browse/TK-448) Switch to using
+  non-recursive directory watching for automatic CRL reloading to avoid failure
+  due to unreadable/inaccessible directories in the SSL dir.
+
 ## 1.8.0
 
 This is a feature release.

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/i18n]
-                 [puppetlabs/trapperkeeper-filesystem-watcher]
+                 [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
                  ]
 
   :source-paths  ["src"]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -963,8 +963,7 @@
    watcher :- (schema/protocol watch-protocol/Watcher)]
   (when-let [crl-path (.getCrlPath ssl-context-factory)]
     (let [normalized-crl-path (.getCanonicalPath (fs/file crl-path))]
-      (watch-protocol/add-watch-dir! watcher (fs/parent crl-path)
-                                     {:recursive true})
+      (watch-protocol/add-watch-dir! watcher (fs/parent crl-path))
       (watch-protocol/add-callback!
        watcher
        (fn [events]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -55,7 +55,7 @@
                started-context (core/start! context config)]
            (if-let [filesystem-watcher-service
                     (maybe-get-service this :FilesystemWatchService)]
-             (let [watcher (watch-protocol/create-watcher filesystem-watcher-service)]
+             (let [watcher (watch-protocol/create-watcher filesystem-watcher-service {:recursive false})]
                (doseq [server (:jetty9-servers started-context)]
                  (when-let [ssl-context-factory (-> server
                                                     second


### PR DESCRIPTION
This commit updates the add-watch-dir! call that we use to watch the crl
directory for changes to use the non-recursive option. We do so to address an
issue we were seeing where during the normal lifecycle of puppetserver run, it
was possible to create a directory that the watch service could not traverse,
causing the service to fail. With recursive false, we do not expect the service
to fail.

Signed-off-by: Moses Mendoza <moses@puppet.com>