### PR TITLE
(SERVER-1597) Add support for renegotiationAllowed configuration

### DIFF
--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -291,6 +291,13 @@ Optional. This describes a path to a Certificate Revocation List file. Incoming
 SSL connections will be rejected if the client certificate matches a
 revocation entry in the file.
 
+### `allow-renegotiation`
+
+Optional. This controls whether the web server will allow client initiated SSL/TLS
+renegotiations. By default this will be disabled since allowing client to renegotiate
+is a vulnerability causing denial of service and information disclosure in certain
+cases. It can be over-ridden by setting this parameter to true.
+
 ### `static-content`
 
 Optional. This is a list of static content to be added to the server as context handlers

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -68,6 +68,7 @@
    "TLS_RSA_WITH_AES_128_CBC_SHA"])
 (def default-protocols ["TLSv1" "TLSv1.1" "TLSv1.2"])
 (def default-client-auth :need)
+(def default-allow-renegotiation false)
 
 ;;;
 ;;; JMX
@@ -117,7 +118,8 @@
    (schema/optional-key :gzip-enable)                schema/Bool
    (schema/optional-key :access-log-config)          schema/Str
    (schema/optional-key :shutdown-timeout-seconds)   schema/Int
-   (schema/optional-key :post-config-script)         schema/Str})
+   (schema/optional-key :post-config-script)         schema/Str
+   (schema/optional-key :allow-renegotiation)        schema/Bool})
 
 (def MultiWebserverRawConfigUnvalidated
   {schema/Keyword  WebserverRawConfig})
@@ -174,7 +176,8 @@
    :client-auth                        WebserverSslClientAuth
    (schema/optional-key :ssl-crl-path) (schema/maybe schema/Str)
    :cipher-suites                      [schema/Str]
-   :protocols                          (schema/maybe [schema/Str])})
+   :protocols                          (schema/maybe [schema/Str])
+   (schema/optional-key :allow-renegotiation)     (schema/maybe schema/Bool)})
 
 (def WebserverSslConnector
   (merge
@@ -388,7 +391,9 @@
             :cipher-suites           (get-cipher-suites-config config)
             :protocols               (get-ssl-protocols-config config)
             :client-auth             (get-client-auth! config)
-            :ssl-crl-path            (get-ssl-crl-path! config)})))
+            :ssl-crl-path            (get-ssl-crl-path! config)
+            :allow-renegotiation     (get config :allow-renegotiation 
+                                         default-allow-renegotiation)})))
 
 (schema/defn ^:always-validate
   maybe-add-http-connector :- {(schema/optional-key :http) WebserverConnector

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -64,6 +64,7 @@
       (update-in [:https :cipher-suites] (fnil identity acceptable-ciphers))
       (update-in [:https :protocols] (fnil identity default-protocols))
       (update-in [:https :client-auth] (fnil identity default-client-auth))
+      (update-in [:https :allow-renegotiation] (fnil identity default-allow-renegotiation))
       (update-in [:https :ssl-crl-path] identity)))
 
 (deftest process-config-http-test
@@ -136,19 +137,22 @@
              (merge valid-ssl-pem-config
                     {:ssl-host "foo.local"}))
            (munge-expected-https-config
-             {:https {:host "foo.local" :port default-https-port}})))
+             {:https {:host "foo.local"
+                      :port default-https-port}})))
 
     (is (= (munge-actual-https-config
              (merge valid-ssl-pem-config
                     {:ssl-port 8001}))
            (munge-expected-https-config
-             {:https {:host default-host :port 8001}})))
+             {:https {:host default-host
+                      :port 8001}}))) 
 
     (is (= (munge-actual-https-config
              (merge valid-ssl-pem-config
                     {:ssl-host "foo.local" :ssl-port 8001}))
            (munge-expected-https-config
-             {:https {:host "foo.local" :port 8001}})))
+             {:https {:host "foo.local"
+                      :port 8001}})))
 
     (is (= (munge-actual-https-config
              (merge valid-ssl-pem-config
@@ -176,7 +180,8 @@
                      :ssl-port    8001
                      :max-threads 93}))
            (munge-expected-https-config
-             {:https       {:host "foo.local" :port 8001}
+             {:https       {:host "foo.local"
+                            :port 8001}
               :max-threads 93})))
 
     (is (= (munge-actual-https-config
@@ -185,7 +190,8 @@
                      :ssl-port       8001
                      :queue-max-size 99}))
            (munge-expected-https-config
-             {:https          {:host "foo.local" :port 8001}
+             {:https          {:host "foo.local"
+                               :port 8001}
               :queue-max-size 99})))
 
     (is (= (munge-actual-https-config
@@ -212,11 +218,32 @@
              (merge valid-ssl-pem-config
                     {:ssl-host             "foo.local"
                      :ssl-port             8001
+                     :allow-renegotiation true}))
+           (munge-expected-https-config
+             {:https {:host             "foo.local"
+                      :port             8001
+                      :allow-renegotiation true}})))
+
+    (is (= (munge-actual-https-config
+             (merge valid-ssl-pem-config
+                    {:ssl-host             "foo.local"
+                     :ssl-port             8001
+                     :allow-renegotiation false}))
+           (munge-expected-https-config
+             {:https {:host             "foo.local"
+                      :port             8001
+                      :allow-renegotiation false}})))
+
+    (is (= (munge-actual-https-config
+             (merge valid-ssl-pem-config
+                    {:ssl-host             "foo.local"
+                     :ssl-port             8001
                      :ssl-acceptor-threads 9193}))
            (munge-expected-https-config
              {:https {:host             "foo.local"
                       :port             8001
                       :acceptor-threads 9193}})))))
+
 
 (deftest process-config-jks-test
   (testing "jks ssl config"
@@ -224,7 +251,8 @@
              (merge valid-ssl-keystore-config
                     {:ssl-port 8001}))
            (munge-expected-https-config
-             {:https {:host default-host :port 8001}})))))
+             {:https {:host default-host
+                      :port 8001}})))))
 
 (deftest process-config-ciphers-test
   (testing "cipher suites"
@@ -318,7 +346,8 @@
                       :idle-timeout-milliseconds nil
                       :acceptor-threads          nil
                       :selector-threads          nil}
-              :https {:host "foo.local" :port default-https-port}})))))
+              :https {:host "foo.local"
+                      :port default-https-port}})))))
 
 (deftest process-config-invalid-test
   (testing "process-config fails for invalid server config"


### PR DESCRIPTION
Introduced a new parameter to disallow renegotiation with default set to true. Done to address security vulnerability that allows a client to DoS any Jetty based puppet service.

This will affect all services using TK-webserver-jetty9. Some limited testing has been done using puppet server. Pl refer to comments in SERVER-1597 and related  tickets if enabling this could adversely impact your service. 
Would like to know if there any acceptance tests that need to be run separately besides this PR. 