### PR TITLE
(maint) Switch to using `lein` instead of `lein2` in Travis

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-lein2 test
+lein test


### PR DESCRIPTION
Travis has stopped including `lein2`, but we don't need to use it
specifically, so this PR updates the Travis script to just use `lein`.