### PR TITLE
(SERVER-2118) Ensure that post request responses can be gzipped

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -13,7 +13,7 @@
            (java.util.concurrent TimeoutException)
            (org.eclipse.jetty.servlet ServletContextHandler ServletHolder DefaultServlet)
            (org.eclipse.jetty.webapp WebAppContext)
-           (org.eclipse.jetty.http MimeTypes HttpHeader HttpHeaderValue)
+           (org.eclipse.jetty.http MimeTypes HttpHeader HttpHeaderValue HttpMethod)
            (javax.servlet Servlet ServletContextListener)
            (org.eclipse.jetty.proxy ProxyServlet)
            (java.net URI)
@@ -394,7 +394,8 @@
   [handler]
   (doto (GzipHandler.)
     (.setHandler handler)
-    (.setExcludedMimeTypes (gzip-excluded-mime-types))))
+    (.setExcludedMimeTypes (gzip-excluded-mime-types))
+    (.addIncludedMethods (into-array [(.asString HttpMethod/POST)]))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Handler Helper Functions

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -50,6 +50,15 @@
         (format "Expected gzipped response, got this response: %s"
                 resp))))
 
+(defn validate-gzip-encoding-when-gzip-requested-on-post-requests
+  [body port]
+  ;; The client/post function asks for compression by default
+  (let [resp (http-sync/post (format "http://localhost:%d/" port))]
+    (is (= (slurp (resp :body)) body))
+    (is (= (get-in resp [:orig-content-encoding]) "gzip")
+        (format "Expected gzipped response, got this response: %s"
+                resp))))
+
 (defn validate-no-gzip-encoding-when-gzip-not-requested
   [body port]
   ;; The client/get function asks for compression by default
@@ -89,6 +98,10 @@
         (testing "a gzipped response when request wants a compressed one and
                   server not configured with a default for gzip-enable"
           (validate-gzip-encoding-when-gzip-requested body port))
+
+        (testing "a gzipped response when a post request asks for a compressed one
+                  and the server not configured with a default for gzip-enable"
+          (validate-gzip-encoding-when-gzip-requested-on-post-requests body port))
 
         (testing "an uncompressed response when request doesn't ask for a
                   compressed one and server not configured with a default for


### PR DESCRIPTION
This commit adds POST requests to the list of HTTP methods that can be
gzipped by jetty. By default, only GET requests can request gzipping,
but we fetch catalogs via a post request, and need that response to be
gzipped as well.