### PR TITLE
(maint) Bump clj-parent version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.4.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.5"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -46,7 +46,7 @@
   :source-paths  ["src"]
   :java-source-paths  ["java"]
 
-  :plugins [[lein-parent "0.3.1"]
+  :plugins [[lein-parent "0.3.4"]
             [puppetlabs/i18n "0.8.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
This commit bumps the clj-parent version to 1.7.5, which is the version used
by PE 2018.1 components. The lein-parent version is also bumped to 0.3.4.