### PR TITLE
(TK-470) Add support for the Mapped Diagnostic Context

### DIFF
--- a/dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml
+++ b/dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml
@@ -2,7 +2,7 @@
 
     <appender name="LIST" class="appender.TestListAppender">
         <encoder>
-            <pattern>%h %l %u %user %date "%r" %s %b</pattern>
+            <pattern>%h %l %u %user %date "%r" %s %b %mdc{mdc-test:-default-mdc-value}</pattern>
         </encoder>
     </appender>
 

--- a/doc/jetty-config.md
+++ b/doc/jetty-config.md
@@ -367,12 +367,20 @@ information about any HTTP requests Jetty receives according to the logging conf
 as long as the XML file pointed to exists and is valid. Information on configuring the
 `Logback-access` module is available [here](http://logback.qos.ch/access.html#configuration).
 
-
 An example configuration file can be found [here](request-logging-example-config.xml). This
 example configures a `FileAppender` that outputs to a file, `access.log`, in the `dev-resources`
-directory. It will log the remote host making the request, the log name, the remote user making
-the request, the date/time of the request, the URL and method of the request, the status of
-the response, and the size in bytes of the response.
+directory. The `pattern` element configures the output format to match the [Apache Combined Log Format](https://httpd.apache.org/docs/2.4/logs.html#combined).
+See the [Logback access layout documentation](https://logback.qos.ch/manual/layouts.html#logback-access)
+for a list of other items that can be added to the `pattern` element.
+
+TrapperKeeper configures the `Logback-access` library with additional support
+for the SLF4J [Mapped Diagnostic Context](https://logback.qos.ch/manual/mdc.html) (MDC).
+This support allows the `%X` and `%mdc` conversion words to be used in the `Logback-access`
+`pattern` which behave as described in the [docs for Logback-classic](https://logback.qos.ch/manual/layouts.html#mdc).
+Jetty is configured to clear any items added to the MDC at the end of each request
+so that incorrect data won't show up in subsequent requests that are handled by
+the same worker thread.
+
 
 ### `shutdown-timeout-seconds`
 

--- a/doc/request-logging-example-config.xml
+++ b/doc/request-logging-example-config.xml
@@ -3,7 +3,9 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>./dev-resources/access.log</file>
         <encoder>
-            <pattern>%h %l %u %user %date "%r" %s %b</pattern>
+            <!-- Logback pattern for Apache Combined Log format
+                 See: https://httpd.apache.org/docs/2.4/logs.html#combined -->
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"<pattern>
         </encoder>
     </appender>
 

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCAccessLogConverter.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCAccessLogConverter.java
@@ -2,11 +2,11 @@ package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
 
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
+
 import ch.qos.logback.core.util.OptionHelper;
 import ch.qos.logback.access.pattern.AccessConverter;
 import ch.qos.logback.access.spi.IAccessEvent;
-
-import org.slf4j.MDC;
 
 /**
  * A Logback pattern converter for logback-access that provides access to
@@ -50,7 +50,12 @@ public class MDCAccessLogConverter extends AccessConverter {
 
   @Override
   public String convert(IAccessEvent accessEvent) {
-    Map<String, String> mdcPropertyMap = MDC.getCopyOfContextMap();
+    Map<String, String> mdcPropertyMap = null;
+    HttpServletRequest request = accessEvent.getRequest();
+
+    if (request != null) {
+      mdcPropertyMap = extractMdcFromRequest(request);
+    }
 
     if (mdcPropertyMap == null) {
       return defaultValue;
@@ -84,5 +89,14 @@ public class MDCAccessLogConverter extends AccessConverter {
     }
 
     return buf.toString();
+  }
+
+  private Map<String, String> extractMdcFromRequest(HttpServletRequest request) {
+    // Will either be null or a Map<String, String> stored by an instance of
+    // the MDCRequestLogHandler class.
+    @SuppressWarnings("unchecked")
+    Map<String, String> result = (Map<String, String>) request.getAttribute(MDCRequestLogHandler.MDC_ATTR);
+
+    return result;
   }
 }

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCAccessLogConverter.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCAccessLogConverter.java
@@ -1,0 +1,88 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
+
+import java.util.Map;
+
+import ch.qos.logback.core.util.OptionHelper;
+import ch.qos.logback.access.pattern.AccessConverter;
+import ch.qos.logback.access.spi.IAccessEvent;
+
+import org.slf4j.MDC;
+
+/**
+ * A Logback pattern converter for logback-access that provides access to
+ * items in the SLF4J Mapped Diagnostic Context (MDC).
+ *
+ * This implementation is adapted from the MDCConverter in logback-classic,
+ * with the modification that MDC data is pulled directly from SLF4J rather
+ * than from the log event object as IAccessEvent has no accessor method for
+ * the MDC at this time. The TrapperKeeper framework configures SLF4J as the
+ * logging interface, so we don't need to worry about abstracting over multiple
+ * backends to the same degree that logback-access does.
+ *
+ * This class may be removable if MDC support lands upstream in logback-access:
+ *
+ *   https://jira.qos.ch/browse/LOGBACK-1016
+ *   https://github.com/qos-ch/logback/pull/359
+ */
+public class MDCAccessLogConverter extends AccessConverter {
+
+  private String key;
+  private String defaultValue = "";
+
+  @Override
+  public void start() {
+    String[] keyInfo = OptionHelper.extractDefaultReplacement(getFirstOption());
+    key = keyInfo[0];
+    if (keyInfo[1] != null) {
+      defaultValue = keyInfo[1];
+    }
+
+    super.start();
+  }
+
+  @Override
+  public void stop() {
+    key = null;
+    defaultValue = "";
+
+    super.stop();
+  }
+
+  @Override
+  public String convert(IAccessEvent accessEvent) {
+    Map<String, String> mdcPropertyMap = MDC.getCopyOfContextMap();
+
+    if (mdcPropertyMap == null) {
+      return defaultValue;
+    }
+
+    if (key == null) {
+      return outputMDCForAllKeys(mdcPropertyMap);
+    } else {
+      String value = mdcPropertyMap.get(key);
+
+      if (value != null) {
+          return value;
+      } else {
+          return defaultValue;
+      }
+    }
+  }
+
+  private String outputMDCForAllKeys(Map<String, String> mdcPropertyMap) {
+    StringBuilder buf = new StringBuilder();
+    boolean first = true;
+
+    for (Map.Entry<String, String> entry : mdcPropertyMap.entrySet()) {
+      if (first) {
+        first = false;
+      } else {
+        buf.append(", ");
+      }
+      // format: key0=value0, key1=value1
+      buf.append(entry.getKey()).append('=').append(entry.getValue());
+    }
+
+    return buf.toString();
+  }
+}

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCRequestLogHandler.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/MDCRequestLogHandler.java
@@ -1,0 +1,52 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.RequestLogHandler;
+
+import org.slf4j.MDC;
+
+/**
+ * An implementation of the Jetty RequestLogHandler that imbues Request objects
+ * with a copy of the SLF4J Mapped Diagnostic Context (MDC) and handles clearing
+ * the MDC after each request.
+ *
+ * Patterned after:
+ *
+ *   https://github.com/jetty-project/jetty-and-logback-example/blob/master/jetty-slf4j-mdc-handler/src/main/java/org/eclipse/jetty/examples/logging/MDCHandler.java
+ */
+public class MDCRequestLogHandler extends RequestLogHandler {
+  public static final String MDC_ATTR = "com.puppetlabs.trapperkeeper.services.webserver.jetty9.MDC";
+
+  @Override
+  public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+          throws IOException, ServletException
+  {
+    // NOTE: Will return null if nothing has been set in the MDC of the worker
+    //       thread currently handling this request.
+    Map<String, String> savedContext = MDC.getCopyOfContextMap();
+
+    try {
+      super.handle(target, baseRequest, request, response);
+
+      // Tag request with a copy of the MDC so that values are accessible if
+      // logging happens in a separate thread.
+      Map<String, String> mdcPropertyMap = MDC.getCopyOfContextMap();
+      baseRequest.setAttribute(MDC_ATTR, mdcPropertyMap);
+    } finally {
+      // Clears any context items created during the request so they don't
+      // contaminate other requests when a worker thread is re-used.
+      if (savedContext != null) {
+        MDC.setContextMap(savedContext);
+      } else {
+        MDC.clear();
+      }
+    }
+  }
+}

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -10,7 +10,8 @@
            (org.codehaus.commons.compiler CompileException)
            (java.lang.reflect InvocationTargetException)
            (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils
-             LifeCycleImplementingRequestLogImpl MDCAccessLogConverter))
+             LifeCycleImplementingRequestLogImpl
+             MDCAccessLogConverter MDCRequestLogHandler))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
@@ -446,7 +447,7 @@
 (schema/defn ^:always-validate
   init-log-handler :- RequestLogHandler
   [config :- WebserverRawConfig]
-  (let [handler (RequestLogHandler.)
+  (let [handler (MDCRequestLogHandler.)
         pattern-rules (HashMap.)
         logger (LifeCycleImplementingRequestLogImpl.)]
     (doseq [pattern ["X" "mdc"]]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -1,12 +1,16 @@
 (ns puppetlabs.trapperkeeper.services.webserver.jetty9-config
-  (:import [java.security KeyStore]
+  (:import (java.security KeyStore)
            (java.io FileInputStream)
+           (java.util HashMap)
+           (ch.qos.logback.access PatternLayout)
+           (ch.qos.logback.core CoreConstants)
            (org.eclipse.jetty.server.handler RequestLogHandler)
            (org.eclipse.jetty.server Server)
            (org.codehaus.janino ScriptEvaluator)
            (org.codehaus.commons.compiler CompileException)
            (java.lang.reflect InvocationTargetException)
-           (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils LifeCycleImplementingRequestLogImpl))
+           (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils
+             LifeCycleImplementingRequestLogImpl MDCAccessLogConverter))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
@@ -443,7 +447,13 @@
   init-log-handler :- RequestLogHandler
   [config :- WebserverRawConfig]
   (let [handler (RequestLogHandler.)
+        pattern-rules (HashMap.)
         logger (LifeCycleImplementingRequestLogImpl.)]
+    (doseq [pattern ["X" "mdc"]]
+      (.put pattern-rules
+            pattern
+            (.getName MDCAccessLogConverter)))
+    (.putObject logger CoreConstants/PATTERN_RULE_REGISTRY pattern-rules)
     (.setFileName logger (:access-log-config config))
     (.setQuiet logger true)
     (.setRequestLog handler logger)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -4,8 +4,7 @@
     (java.security KeyStore)
     (java.net SocketTimeoutException Socket)
     (java.io InputStreamReader BufferedReader PrintWriter)
-    (org.eclipse.jetty.server Server ServerConnector)
-    (appender TestListAppender))
+    (org.eclipse.jetty.server Server ServerConnector))
   (:require [clojure.test :refer :all]
             [clojure.java.jmx :as jmx]
             [ring.util.response :as rr]
@@ -128,7 +127,6 @@
                    gzip-enable"
            (validate-no-gzip-encoding-when-gzip-not-requested body port)))
 
-      (try
         (with-test-webserver-and-config
          app
          port {:gzip-enable true
@@ -138,9 +136,7 @@
          (testing "(TK-429) a gzipped response when request wants a compressed one
                  and server configured with a true value for gzip-enable and an
                  access-log-config"
-           (validate-gzip-encoding-when-gzip-requested body port)))
-        (finally
-          (.clear (TestListAppender/list)))))))
+           (validate-gzip-encoding-when-gzip-requested body port))))))
 
 (deftest jmx
   (testing "by default Jetty JMX support is enabled"

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -699,23 +699,20 @@
         (Files/delete link)))))
 
 (deftest request-logging-test
-  (try
+  (with-app-with-config
+   app
+   [jetty9-service hello-webservice]
+   {:webserver {:port 8080
+                :access-log-config
+                "./dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml"}}
     (testing "request logging occurs when :access-log-config is configured"
-      (with-app-with-config
-       app
-       [jetty9-service
-        hello-webservice]
-       {:webserver {:port 8080
-                    :access-log-config
-                    "./dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml"}}
+      (with-test-access-logging
        (http-get "http://localhost:8080/hi_world/")
        ; Logging is done in a separate thread from Jetty and this test. As a result,
        ; we have to sleep the thread to avoid a race condition.
        (Thread/sleep 10)
        (let [list (TestListAppender/list)]
-         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200 8\n" (first list))))))
-    (finally
-      (.clear (TestListAppender/list)))))
+         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200 8\n" (first list))))))))
 
 (deftest graceful-shutdown-test
   (testing "jetty9 webservers shut down gracefully by default"

--- a/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
@@ -10,6 +10,10 @@
   ([url options]
    (http-client/get url options)))
 
+(defn http-put
+  [url options]
+  (http-client/put url options))
+
 (def jetty-plaintext-config
   {:webserver {:port 8080}})
 

--- a/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/webserver/common.clj
@@ -1,5 +1,8 @@
 (ns puppetlabs.trapperkeeper.testutils.webserver.common
-  (:require [puppetlabs.http.client.sync :as http-client]))
+  (:require
+    [puppetlabs.http.client.sync :as http-client])
+  (:import
+    (appender TestListAppender)))
 
 (defn http-get
   ([url]
@@ -55,3 +58,15 @@
   (apply str (repeat 8192 "a")))
 
 (def dev-resources-dir        "./dev-resources/")
+
+
+(defmacro with-test-access-logging
+  "Executes a test block and clears any messages saved to the TestListAppender
+  before and afterwards."
+  [& body]
+  `(do
+     (.clear (TestListAppender/list))
+     (try
+       (do ~@body)
+       (finally
+         (.clear (TestListAppender/list))))))


### PR DESCRIPTION
This PR enhances the Jetty handlers to provide access to the SLF4J [Mapped Diagnostic Context](https://logback.qos.ch/manual/mdc.html) (MDC). The MDC is a thread-local storage for diagnostic information that can be directly accessed by Logback loggers.

The commits in this PR provide the following features when access logging is enabled:

  - A snapshot of the data in the MDC is taken at the end of each request and folded into the request instance. The MDC is also restored to the state it had at the beginning of the request so that diagnostic data does not leak between requests that are handled by the same worker thread.

  - The logback-access library is configured with support for the `%X` and `%mdc` pattern conversion words used by `logback-classic`. These can be used to add data stored in the MDC to the access log output. For example, if Puppet Server measured the amount of time a JRuby instance was borrowed to service a request and stored it in the MDC as `jruby.borrow-time`, then that value could be inserted into the access log using:

        %mdc{jruby.borrow-time:-0}

The `:-0` on the end denotes that a default value of "0" should be used if no value for `jruby.borrow-time` was stored in the MDC.