### PR TITLE
(TK-473) Stop reporting jetty version in responses

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -242,7 +242,8 @@
 (defn- http-configuration
   [request-header-size]
   (let [http-config (doto (HttpConfiguration.)
-                      (.setSendDateHeader true))]
+                      (.setSendDateHeader true)
+                      (.setSendServerVersion false))]
     (if request-header-size
       (.setRequestHeaderSize http-config request-header-size))
     http-config))


### PR DESCRIPTION
Previously, responses from jetty included a `Server` header with the
jetty version. Because we package applications as uberjars, making the
jetty manifest inaccessible, the server version was imprecise (ie.
9.4.z-SNAPSHOT vs. 9.4.11.v20180605). That fact makes the version header
not particularly useful and can also confuse security scanners, which
can't determine whether the server is patched for a particular
vulnerability.

This commit disables sending the `Server` header in responses. It also
prevents default HTML responses from including the server version. No
option is provided to reenable the header, since it's not really useful
and there's presently no reason to include it.