### PR TITLE
(maint) Remove explicit nrepl dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,6 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/java.jmx]
                  [org.clojure/tools.logging]
-                 [org.clojure/tools.nrepl "0.2.13"]
 
                  [org.codehaus.janino/janino]
 


### PR DESCRIPTION
This explicit nrepl dependency is on an older nrepl, and causes conflicts
when users of this library attempt to use the newer nrepl.

Users of this library should specify their own nrepl dependency.

This pairs with puppetlabs/clj-parent#155