### PR TITLE
(PCP-862) Only disconnect if the connection is not closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.1
+
+* [PCP-862](https://tickets.puppetlabs.com/browse/PCP-862) Only disconnect if
+  the session has not already been closed.
+
 ## 2.4.0
 
 * [PCP-862](https://tickets.puppetlabs.com/browse/PCP-862) Add disconnect

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "9.4.11.v20180605")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "2.5.0-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-webserver-jetty9 "2.4.1-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
@@ -45,7 +45,8 @@
     ([this code reason]
      (.. this (getSession) (close code reason))))
   (disconnect [this]
-     (.. this (getSession) (disconnect)))
+    (when-let [session (.getSession this)]
+     (.disconnect session)))
   (remote-addr [this]
     (.. this (getSession) (getRemoteAddress)))
   (ssl? [this]


### PR DESCRIPTION
When disconnect is called on a connection that is already closed it throws an error. We only want to disconnect if the connection has not already been closed, so this adds an if block to check that `getSession` is not null before disconnecting the session.