### PR TITLE
(SERVER-2576) Loosen schema to allow so-linger-seconds key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.0.1
+
+This is a bug fix release
+
+With this release we no longer fail to start if so-linger-seconds is set,
+only warn the user that the seeting will be ignored. This should allow
+easier upgrade paths.
+
+
 ## 3.0.0
 
 This is a feature release with backwards breaking changes.


### PR DESCRIPTION
Prior to 3.0 we allowed and claimed to honor setting the socket linger
setting. In 3.0 we removed this setting since it was removed in Jetty
after the maintainers found out that it had undefined behavior on their
target platforms.

Unfortunately, none of the projects that pull in tk-jetty9 wrap the
configuration parsing sufficiently to intercept this configuration and
provide a kinder upgrade path. Nor are those projects in a position to
break their config APIs in a release soon.

Consequently, we now allow the old config value in our schema, though
ignore it in further processing to provide a smoother upgrade path to
users.