### PR TITLE
(maint) Suppress warning about empty contextPath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,3 @@ jdk:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
-
-# workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
-addons:
-  hosts:
-    - myshorthost
-  hostname: myshorthost

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -739,6 +739,7 @@
         (normalized-uri-helpers/handler-maybe-wrapped-with-normalized-uri
          (ring-handler handler)
          normalize-request-uri?)
+        path (if (= "" path) "/" path)
         ctxt-handler (doto (ContextHandler. path)
                        (.setHandler handler))]
     (add-handler webserver-context ctxt-handler enable-trailing-slash-redirect?)))


### PR DESCRIPTION
Jetty warns if a contextPath is an empty string. Since that is normal in
clients of this library, substitute "/" in this case, which is what
jetty ends up using anyway.