### PR TITLE
(PE-26658) update clj-parent to pick up fips work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,21 @@ jobs:
       # in the Travis CI web page
       env:
         - FIPS=false
-    #- # still jdk8
-    #  script: lein with-profile fips test
-    #  jdk: openjdk8
-    #  env:
-    #    - FIPS=true
+    - # still jdk8
+      script: lein with-profile fips test
+      jdk: openjdk8
+      env:
+        - FIPS=true
 
     - stage: jdk11
       script: lein with-profile dev test
       jdk: openjdk11
       env:
         - FIPS=false
-    #- # still jdk11
-    #  script: lein with-profile fips test
-    #  jdk: openjdk11
-    #  env:
-    #    - FIPS=true
+    - # still jdk11
+      script: lein with-profile fips test
+      jdk: openjdk11
+      env:
+        - FIPS=true
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.8.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.4"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
Updates clj-parent for new clj-http-client and enables FIPS tests