### PR TITLE
(maint) fixing misconfiguration causing noise

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -6,9 +6,9 @@
     </appender>
 
     <logger name="org.apache.http" level="warn"/>
-    <logger name="org.eclipse.jetty" level="warn"/>
+    <logger name="org.eclipse.jetty" level="info"/>
 
-    <root level="warn">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_config.clj
@@ -10,8 +10,9 @@
            (org.codehaus.commons.compiler CompileException)
            (java.lang.reflect InvocationTargetException)
            (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils
-             LifeCycleImplementingRequestLogImpl
-             MDCAccessLogConverter MDCRequestLogHandler))
+            LifeCycleImplementingRequestLogImpl
+            MDCAccessLogConverter MDCRequestLogHandler)
+           (com.puppetlabs.ssl_utils SSLUtils))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
@@ -64,6 +65,11 @@
    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"])
+
+(def acceptable-ciphers-fips
+  ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+   "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"])
 
 (def default-protocols ["TLSv1.2"])
 (def default-client-auth :need)
@@ -342,7 +348,9 @@
      :else default)))
 
 (defn get-cipher-suites-config [config]
-  (get-or-parse-sequential-config-value config :cipher-suites acceptable-ciphers))
+  (get-or-parse-sequential-config-value config :cipher-suites (if (SSLUtils/isFIPS)
+                                                                acceptable-ciphers-fips
+                                                                acceptable-ciphers)))
 
 (defn get-ssl-protocols-config [config]
   (get-or-parse-sequential-config-value config :ssl-protocols default-protocols))

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -225,7 +225,8 @@
       (doto context
         (.setKeyStoreType SSLUtils/BOUNCYCASTLE_FIPS_KEYSTORE)
         (.setTrustStoreType SSLUtils/BOUNCYCASTLE_FIPS_KEYSTORE)
-        (.setProvider SSLUtils/BOUNCYCASTLE_JSSE_PROVIDER)
+        (.setKeyStoreProvider SSLUtils/FIPS_PROVIDER_CLASS)
+        (.setTrustStoreProvider SSLUtils/FIPS_PROVIDER_CLASS)
         (.setKeyManagerFactoryAlgorithm SSLUtils/PKIX_KEYMANAGER_ALGO)
         (.setTrustManagerFactoryAlgorithm SSLUtils/PKIX_KEYMANAGER_ALGO)))
     (if (:trust-password keystore-config)
@@ -252,7 +253,9 @@
                          (config/pem-ssl-config->keystore-ssl-config
                            ssl-config)
                         :client-auth :none
-                        :cipher-suites (or (:cipher-suites ssl-config) config/acceptable-ciphers)
+                        :cipher-suites (or (:cipher-suites ssl-config) (if (SSLUtils/isFIPS)
+                                                                         config/acceptable-ciphers-fips
+                                                                         config/acceptable-ciphers))
                         :protocols     (or (:protocols ssl-config) config/default-protocols)
                         :allow-renegotiation  (or (:allow-renegotiation ssl-config)
                                                   config/default-allow-renegotiation)}))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -63,7 +63,9 @@
 (defn munge-expected-https-config
   [expected]
   (-> (munge-expected-common-config expected :https)
-      (update-in [:https :cipher-suites] (fnil identity acceptable-ciphers))
+      (update-in [:https :cipher-suites] (fnil identity (if (SSLUtils/isFIPS)
+                                                          acceptable-ciphers-fips
+                                                          acceptable-ciphers)))
       (update-in [:https :protocols] (fnil identity default-protocols))
       (update-in [:https :client-auth] (fnil identity default-client-auth))
       (update-in [:https :allow-renegotiation] (fnil identity default-allow-renegotiation))


### PR DESCRIPTION
Fixing some wiring to the SslContextFactory in FIPS mode that was
causing jetty to be extra noisy. Specifically, this will stop these log
messages from occurring:

    2019-10-16 12:04:50,761 INFO  [o.e.j.u.s.SslContextFactory] No Cipher matching 'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256' is supported
    2019-10-16 12:04:50,761 INFO  [o.e.j.u.s.SslContextFactory] No Cipher matching 'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384' is supported
    2019-10-16 12:04:50,761 INFO  [o.e.j.u.s.SslContextFactory] No Cipher matching 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' is supported
    2019-10-16 12:04:52,769 INFO  [o.e.j.u.s.SslContextFactory] Unable to get CertificateFactory instance for type [X.509] on provider [BCJSSE], using default

Note: this involved removing three supported ciphers from the default
list, so that will require additional testing. Downstream consumers of
tk-jetty9 will also want to update their configured cipher lists in FIPS
mode.