### PR TITLE
(SERVER-2734) Disambiguate overloaded method call

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -737,7 +737,7 @@
          follow-links? (:follow-links? options)
          enable-trailing-slash-redirect? (:enable-trailing-slash-redirect? options)
          normalize-request-uri? (:normalize-request-uri? options)]
-     (.setBaseResource handler (Resource/newResource base-path))
+     (.setBaseResource handler (Resource/newResource ^String base-path))
      (if follow-links?
        (.setAliasChecks handler [(AllowSymLinkAliasChecker.)])
        (.clearAliasChecks handler))


### PR DESCRIPTION
This commit adds a type annotation to indicate which version of Jetty's
`newResource` function is desired.