### PR TITLE
Upgrade to latest jetty

### DIFF
--- a/java/org/eclipse/jetty/util/OldURIUtil.java
+++ b/java/org/eclipse/jetty/util/OldURIUtil.java
@@ -1,0 +1,206 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.Utf8Appendable.NotUtf8Exception;
+import org.eclipse.jetty.util.Utf8StringBuilder;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+
+/**
+ * URI Utility methods.
+ * <p>
+ * This class assists with the decoding and encoding or HTTP URI's.
+ * It differs from the java.net.URL class as it does not provide
+ * communications ability, but it does assist with query string
+ * formatting.
+ * </p>
+ *
+ * @see UrlEncoded
+ */
+public class OldURIUtil
+        implements Cloneable
+{
+    private static final Logger LOG = Log.getLogger(OldURIUtil.class);
+
+    private OldURIUtil()
+    {}
+
+    /* ------------------------------------------------------------ */
+    /* Decode a URI path and strip parameters
+     */
+    public static String decodePath(String path)
+    {
+        return decodePath(path,0,path.length());
+    }
+
+    /* ------------------------------------------------------------ */
+    /* Decode a URI path and strip parameters of UTF-8 path
+     */
+    public static String decodePath(String path, int offset, int length)
+    {
+        try
+        {
+            Utf8StringBuilder builder=null;
+            int end=offset+length;
+            for (int i=offset;i<end;i++)
+            {
+                char c = path.charAt(i);
+                switch(c)
+                {
+                    case '%':
+                        if (builder==null)
+                        {
+                            builder=new Utf8StringBuilder(path.length());
+                            builder.append(path,offset,i-offset);
+                        }
+                        if ((i+2)<end)
+                        {
+                            char u=path.charAt(i+1);
+                            if (u=='u')
+                            {
+                                // TODO this is wrong. This is a codepoint not a char
+                                builder.append((char)(0xffff&TypeUtil.parseInt(path,i+2,4,16)));
+                                i+=5;
+                            }
+                            else
+                            {
+                                builder.append((byte)(0xff&(TypeUtil.convertHexDigit(u)*16+TypeUtil.convertHexDigit(path.charAt(i+2)))));
+                                i+=2;
+                            }
+                        }
+                        else
+                        {
+                            throw new IllegalArgumentException("Bad URI % encoding");
+                        }
+
+                        break;
+
+                    case ';':
+                        if (builder==null)
+                        {
+                            builder=new Utf8StringBuilder(path.length());
+                            builder.append(path,offset,i-offset);
+                        }
+
+                        while(++i<end)
+                        {
+                            if (path.charAt(i)=='/')
+                            {
+                                builder.append('/');
+                                break;
+                            }
+                        }
+
+                        break;
+
+                    default:
+                        if (builder!=null)
+                            builder.append(c);
+                        break;
+                }
+            }
+
+            if (builder!=null)
+                return builder.toString();
+            if (offset==0 && length==path.length())
+                return path;
+            return path.substring(offset,end);
+        }
+        catch(NotUtf8Exception e)
+        {
+            LOG.warn(path.substring(offset,offset+length)+" "+e);
+            LOG.debug(e);
+            return decodeISO88591Path(path,offset,length);
+        }
+    }
+
+
+    /* ------------------------------------------------------------ */
+    /* Decode a URI path and strip parameters of ISO-8859-1 path
+     */
+    private static String decodeISO88591Path(String path, int offset, int length)
+    {
+        StringBuilder builder=null;
+        int end=offset+length;
+        for (int i=offset;i<end;i++)
+        {
+            char c = path.charAt(i);
+            switch(c)
+            {
+                case '%':
+                    if (builder==null)
+                    {
+                        builder=new StringBuilder(path.length());
+                        builder.append(path,offset,i-offset);
+                    }
+                    if ((i+2)<end)
+                    {
+                        char u=path.charAt(i+1);
+                        if (u=='u')
+                        {
+                            // TODO this is wrong. This is a codepoint not a char
+                            builder.append((char)(0xffff&TypeUtil.parseInt(path,i+2,4,16)));
+                            i+=5;
+                        }
+                        else
+                        {
+                            builder.append((byte)(0xff&(TypeUtil.convertHexDigit(u)*16+TypeUtil.convertHexDigit(path.charAt(i+2)))));
+                            i+=2;
+                        }
+                    }
+                    else
+                    {
+                        throw new IllegalArgumentException();
+                    }
+
+                    break;
+
+                case ';':
+                    if (builder==null)
+                    {
+                        builder=new StringBuilder(path.length());
+                        builder.append(path,offset,i-offset);
+                    }
+                    while(++i<end)
+                    {
+                        if (path.charAt(i)=='/')
+                        {
+                            builder.append('/');
+                            break;
+                        }
+                    }
+                    break;
+
+
+                default:
+                    if (builder!=null)
+                        builder.append(c);
+                    break;
+            }
+        }
+
+        if (builder!=null)
+            return builder.toString();
+        if (offset==0 && length==path.length())
+            return path;
+        return path.substring(offset,end);
+    }
+}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.18.v20190429")
+(def jetty-version "9.4.27.v20200227")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.0.4-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."

--- a/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.trapperkeeper.services.webserver.normalized-uri-helpers
   (:import (javax.servlet.http HttpServletRequest HttpServletResponse)
-           (org.eclipse.jetty.util URIUtil)
+           (org.eclipse.jetty.util OldURIUtil URIUtil)
            (org.eclipse.jetty.server Request)
            (org.eclipse.jetty.server.handler HandlerWrapper AbstractHandler)
            (com.puppetlabs.trapperkeeper.services.webserver.jetty9.utils
@@ -35,7 +35,7 @@
   [request :- HttpServletRequest]
   (let [percent-decoded-uri-path (-> request
                                      (.getRequestURI)
-                                     (URIUtil/decodePath))
+                                     (OldURIUtil/decodePath))
         canonicalized-uri-path (URIUtil/canonicalPath percent-decoded-uri-path)]
     (if (or (nil? canonicalized-uri-path)
             (not= (.length percent-decoded-uri-path)

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
@@ -792,7 +792,7 @@
                      ; because the ring handler didn't understand the request, which
                      ; would have a different message in the body. The request shouldn't
                      ; get as far as the hello-goodbye-count-ring-handler
-                     (is (re-find #"Problem accessing /hello-proxy" (:body response))))))
+                     (is (re-find #"HTTP ERROR 404 Not Found" (:body response))))))
           ; Counter should still be at 0
           (is (= 0 (deref goodbye-counter))))
         (testing "counter is working correctly"


### PR DESCRIPTION
Uses latest (9.4.27.v20200227) version of Jetty.  This version,
however, breaks tests because it incorrectly decodes overlong UTF-8
text (specifically normalize-uri-with-overlong-utf8-chars-tests).  To
avoid potential security issues the 9.4.18 version of
URIUtil.decodePath has been copy/pasted.