### PR TITLE
(SERVER-2800) Update Jetty to 9.4.28

### DIFF
--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty9/utils/InternalSslContextFactory.java
@@ -10,7 +10,7 @@ import java.security.cert.CRL;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-public class InternalSslContextFactory extends SslContextFactory {
+public class InternalSslContextFactory extends SslContextFactory.Server {
 
     private static int maxTries = 25;
     private static int sleepInMillisecondsBetweenTries = 100;

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def jetty-version "9.4.18.v20190429")
+(def jetty-version "9.4.28.v20200408")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.0.4-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.1.0-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -207,7 +207,6 @@
                   (.setKeyStore (:keystore keystore-config))
                   (.setKeyStorePassword (:key-password keystore-config))
                   (.setTrustStore (:truststore keystore-config))
-                  (.setEndpointIdentificationAlgorithm nil)
                   ;; Need to clear out the default cipher suite exclude list so
                   ;; that Jetty doesn't potentially remove one or more ciphers
                   ;; that we want to be included.

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
@@ -787,12 +787,7 @@
         (testing "non-proxied endpoint doesn't see any traffic"
           (doall (for [bad-request bad-proxy-requests]
                    (let [response (http-get bad-request default-options-for-https-client)]
-                     (is (= 404 (:status response)))
-                     ; Make sure the 404 is because jetty couldn't find the page, not
-                     ; because the ring handler didn't understand the request, which
-                     ; would have a different message in the body. The request shouldn't
-                     ; get as far as the hello-goodbye-count-ring-handler
-                     (is (re-find #"Problem accessing /hello-proxy" (:body response))))))
+                     (is (= 404 (:status response))))))
           ; Counter should still be at 0
           (is (= 0 (deref goodbye-counter))))
         (testing "counter is working correctly"

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/normalized_uri_helpers_test.clj
@@ -102,22 +102,9 @@
 (deftest normalize-uri-with-overlong-utf8-chars-tests
   (testing (str "utf-8 characters with overlong encodings are substituted "
                 "with replacement characters")
-    ;; %C0%AE is an overlong (leading zero-padded, two byte) encoding of the
-    ;; full stop (period) character.  The full stop character's minimal
-    ;; encoding in UTF-8 is %2E.  These tests validate that the normalization
-    ;; process substitutes replacement characters for the original characters
-    ;; in the string - as opposed to decoding the character back to the
-    ;; same character that the minimal form would decode to.
-    ;;
-    ;; From section 3 of RFC 3629 (https://tools.ietf.org/html/rfc3629):
-    ;;> Implementations of the decoding algorithm above MUST protect against
-    ;;> decoding invalid sequences.  For instance, a naive implementation may
-    ;;> decode the overlong UTF-8 sequence C0 80 into the character U+0000,
-    ;;> or the surrogate pair ED A1 8C ED BE B4 into U+233B4.  Decoding
-    ;;> invalid sequences may have security consequences or cause other
-    ;;> problems.
-    (is (= "-64-82" (normalize-uri-path-for-string "%C0%AE")))
-    (is (= "/foo/-64-82/-64-82" (normalize-uri-path-for-string "/foo/%C0%AE/%C0%AE")))))
+    ;; These are explicitly handled by Jetty as of 9.4.23
+    (is (= "À®" (normalize-uri-path-for-string "%C0%AE")))
+    (is (= "/foo/À®/À®" (normalize-uri-path-for-string "/foo/%C0%AE/%C0%AE")))))
 
 (deftest normalize-uris-with-redundant-slashes-tests
   (testing "uris with redundant slashes are removed"


### PR DESCRIPTION
This updates us to the newest Jetty verion.

This required two changes. One was test changes around CVE-2016-2785 and
the other involves our custom SslContextFactory.

For background on CVE-2016-2785, see
[TK-343](https://tickets.puppetlabs.com/browse/TK-343) about how certain
percent encodings could be used to create a directory traversal attack.

In [#4033](https://github.com/eclipse/jetty.project/issues/4033), the
Jetty maintainers, in response to a user who got an NPE when attempting
to serve files from his jar by percent encoding a jar path, loosened the
percent encoding rules. Quickly after merging those loosened validation
rules, it was reverted and the rules were additionally tightened up. As
part of that tightening, some of the dangerous percent encodings Jetty
used to let through (and we explicitly tested received an error from our
middleware) no longer are allowed. Despite removing the assertion that
we see the specific error message from our middleware we still check
that the directory attacks receive a 404 and the primary handler never
sees the request.

Previously, Jetty deprecated the SslContextFactory that we extend to
provide custom CRL reloading. It also moved the
endpointIdentificationAlgorithm setting to specialized inner classes,
either SslContextFactory.Server or SslContextFactory.Client depending on
what defaults are required. With the latest updates attempting to extend
the deprecated SslContextFactory raises and we must now extend the inner
class SslContextFactory.Server. As a side effect we now no longer need
to manually set the endpointIdentificationAlgorithm.