### PR TITLE
(maint) Update flatland to 1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.1.3
+
+Update flatland/ordered to 1.5.9, to avoid conflicting with other libs.
+
+## 4.1.2
+
+Ship artifacts with Java 8 builds.
+
 ## 4.1.1
 
 Update jetty version to 9.4.36. This is a maintenance update.

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.11"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.13"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -20,7 +20,7 @@
                  [org.clojure/tools.logging]
 
                  [org.codehaus.janino/janino]
-                 [org.flatland/ordered "1.5.7"]
+                 [org.flatland/ordered "1.5.9"]
 
                  [javax.servlet/javax.servlet-api "3.1.0"]
                  ;; Jetty Webserver


### PR DESCRIPTION
This commit updates flatland to latest, to match what's pulled in by
other libraries, notably clj-yaml.