### PR TITLE
(SEC-431) update jetty to 9.4.39.v20210325 to resolve CVEs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.36.v20210114")
+(def jetty-version "9.4.39.v20210325")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.1.5-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."


### PR DESCRIPTION
- CVE-2021-28165 - #6072 - jetty server high CPU when client send data length > 17408
- CVE-2021-28164 - #6101 - Normalize ambiguous URIs
- CVE-2021-28163 - #6102 - Exclude webapps directory from deployment scan