### PR TITLE
(PE-31797) Upgrade jetty to 9.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.6
+
+Update jetty to 9.4.40 to attempt to avoid a connection reset bug.
+
 ## 4.1.5
 
 Update jetty to 9.4.39.v20210325 to resolve CVEs:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.39.v20210325")
+(def jetty-version "9.4.40.v20210413")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.1.6-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."


### PR DESCRIPTION
Jetty 9.39 seems to be causing some issues in Puppet Server, so this
commit rolls us forward to the next version that was just released,
which might have a fix for connections getting reset.