### PR TITLE
(SERVER-3035) Update Jetty to 9.4.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.7
+
+Update Jetty to 9.4.42 to resolve CVE-2021-28169
+
 ## 4.1.6
 
 Update jetty to 9.4.40 to attempt to avoid a connection reset bug.

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.25"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.40.v20210413")
+(def jetty-version "9.4.42.v20210604")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.1.7-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_config_test.clj
@@ -451,7 +451,7 @@
             (testing "scripted changes are executed properly"
               (add-ring-handler ring-handler path)
               (let [response (http-get
-                               (format "http://localhost:10000/%s" path))]
+                               (format "http://localhost:10000%s" path))]
                 (is (= (:status response) 200))
                 (is (= (:body response) body)))))))))
 


### PR DESCRIPTION
We do not currently use the features affected by CVE-2021-28169, however
we should take this opportunity to update to the latest z release of
Jetty.

Here is the Jetty changelog:

```
jetty-9.4.42.v20210604 - 04 June 2021
 + 5379 Better handling for wrong SNI
 + 5931 SslConnection should implement getBytesIn()/getBytesOut()
 + 6118 Display a warning when Hazelcast configuration does not contain Jetty
   session serializer
 + 6276 Support non-standard domains in SNI and X509
 + 6287 Class loading broken for WebSocketClient used inside webapp
 + 6323 HttpClient gets stuck/never calls onComplete() when multiple requests
   with timeouts are sent

jetty-9.4.41.v20210516 - 16 May 2021
 + 6099 Cipher preference may break SNI if certificates have different key
   types
 + 6186 Add Null Protection on Log / Logger
 + 6205 OpenIdAuthenticator may use incorrect redirect
 + 6208 HTTP/2 max local stream count exceeded
 + 6227 Better resolve race between `AsyncListener.onTimeout` and
   `AsyncContext.dispatch`
 + 6254 Total timeout not enforced for queued requests
 + 6263 Review URI encoding in ConcatServlet & WelcomeFilter (Resolved CVE-2021-28169)
 + 6277 Better handle exceptions thrown from session destroy listener
 + 6280 Copy ServletHolder class/instance properly during startWebapp

```