### PR TITLE
(maint) bump jetty to 9.4.48.v20220622

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+* update to Jetty 9.4.48 for additional bug fixes
+
 ## 4.3.0
 
 (maint) Update to Jetty 9.4.44 for small bug fixes and dependency bumps

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.44.v20210927")
+(def jetty-version "9.4.48.v20220622")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.3.1-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
@@ -117,5 +117,5 @@
   :main puppetlabs.trapperkeeper.main
 
   :repositories [["puppet-releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
-                 ["puppet-snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]]
-  )
+                 ["puppet-snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]])
+


### PR DESCRIPTION
This updates jetty to 9.4.48.  From the jetty changelog:

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.47.v20220610
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.46.v20220331
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.45.v20220203