### PR TITLE
(maint) update clj-parent to 5.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.9.1
+lein: 2.9.10
 jobs:
   include:
     - stage: jdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.0
+* update clj-parent which moves to the `18on` series of bouncy castle from the `15on` series.
+
 ## 4.3.1
 * update to Jetty 9.4.48 for additional bug fixes
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "9.4.48.v20220622")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.3.2-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.4.0-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.9.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.6"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -84,18 +84,18 @@
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
 
              :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}]
+                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
-             :provided {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+             :provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                         :resource-paths ["dev-resources"]}
 
              :fips [:defaults ; merge in the dev profile
                     {:dependencies [[org.bouncycastle/bcpkix-fips]
                                     [org.bouncycastle/bc-fips]
                                     [org.bouncycastle/bctls-fips]]
-                     :exclusions [[org.bouncycastle/bcpkix-jdk15on]]
+                     :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
                      ;; this only ensures that we run with the proper profiles
                      ;; during testing. This JVM opt will be set in the puppet module
                      ;; that sets up the JVM classpaths during installation.

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -938,9 +938,8 @@
       jetty-ssl-pem-config
       (let [test-fn (fn [] (http-get "https://localhost:8081/hi_world" (merge default-options-for-https-client
                                                                              {:ssl-protocols ["SSLv3"]})) )]
-       (if (SSLUtils/isFIPS)
-         (is (thrown? IllegalArgumentException (test-fn)))
-         (is (thrown? SSLException (test-fn)))))))
+
+        (is (thrown? SSLException (test-fn))))))
   (testing "SSLv3 is not supported even when configured"
     (tk-log-testutils/with-test-logging
      (with-app-with-config
@@ -954,6 +953,4 @@
       (is (logged? #"When `ssl-protocols` is empty, a default of"))
       (let [test-fn (fn [] (http-get "https://localhost:8081/hi_world" (merge default-options-for-https-client
                                                                               {:ssl-protocols ["SSLv3"]})) )]
-        (if (SSLUtils/isFIPS)
-          (is (thrown? IllegalArgumentException (test-fn)))
-          (is (thrown? SSLException (test-fn)))))))))
+        (is (thrown? SSLException (test-fn))))))))


### PR DESCRIPTION
This updates clj-parent to 5.2.6 to include the new version of bouncy-castle which has been renamed from `15on` to `18on` to indicate that it is now only jdk8 and beyond compatible.

Additionally the changelog was updated to prepare for a new 4.4.0 release.