### PR TITLE
(PE-34658) Bump clj-parent to remove stylefruits/gniazdo version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.1
+* update clj-parent to 5.2.9, which includes the stylefruits/gniazdo dependency.
+
 ## 4.4.0
 * update clj-parent which moves to the `18on` series of bouncy castle from the `15on` series.
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.2.6"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.9"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -76,9 +76,9 @@
                                        [puppetlabs/trapperkeeper nil :classifier "test"]
                                        [org.clojure/tools.namespace]
                                        [compojure]
-                                       [stylefruits/gniazdo "1.1.1" :exclusions [org.eclipse.jetty.websocket/websocket-api
-                                                                                 org.eclipse.jetty.websocket/websocket-client
-                                                                                 org.eclipse.jetty/jetty-util]]
+                                       [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
+                                                                             org.eclipse.jetty.websocket/websocket-client
+                                                                             org.eclipse.jetty/jetty-util]]
                                        [ring/ring-core]]
                         :resource-paths ["dev-resources"]
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}


### PR DESCRIPTION
This updates the clj-parent version to 5.2.9, which contains a version declaration for stylefruits/gniazdo, allowing the version in this repository to not pin a specific version.