### PR TITLE
(maint) remove dependency on stylefruits/gniazdo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,15 +76,13 @@
                                        [puppetlabs/trapperkeeper nil :classifier "test"]
                                        [org.clojure/tools.namespace]
                                        [compojure]
-                                       [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
-                                                                             org.eclipse.jetty.websocket/websocket-client
-                                                                             org.eclipse.jetty/jetty-util]]
                                        [ring/ring-core]]
                         :resource-paths ["dev-resources"]
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
 
              :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
+                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
+                                   [hato "0.8.2"]]}]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
@@ -118,4 +116,3 @@
 
   :repositories [["puppet-releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
                  ["puppet-snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]])
-

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
@@ -1,25 +1,22 @@
 (ns puppetlabs.trapperkeeper.services.webrouting.webrouting-service-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [gniazdo.core :as ws-client]
+            [hato.websocket :as ws]
             [puppetlabs.experimental.websockets.client :as ws-session]
             [puppetlabs.kitchensink.testutils.fixtures :as ks-test-fixtures]
             [puppetlabs.trapperkeeper.app :as tk-app]
-            [puppetlabs.trapperkeeper.core :as tk-core]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service
              :refer :all]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service
              :refer [jetty9-service]]
-            [puppetlabs.trapperkeeper.testutils.webrouting.common :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap
-             :refer [with-app-with-empty-config
-                     with-app-with-config]]
+             :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging
              :refer [with-test-logging]]
-            [schema.core :as schema]
-            [schema.test :as schema-test]
-            [puppetlabs.trapperkeeper.testutils.webserver :as testutils]))
+            [puppetlabs.trapperkeeper.testutils.webrouting.common :refer :all]
+            [puppetlabs.trapperkeeper.testutils.webserver :as testutils]
+            [schema.test :as schema-test]))
 
 (use-fixtures :once
   ks-test-fixtures/with-no-jvm-shutdown-hooks
@@ -125,10 +122,10 @@
           (is (= (:status response) 200))
           (is (= (:body response) "Hello World!")))
         (let [message   (promise)
-              websocket (ws-client/connect "ws://localhost:8080/baz"
-                                           :on-receive (fn [text] (deliver message text)))]
-          (is (= @message "heyo"))
-          (ws-client/close websocket))))
+              websocket @(ws/websocket "ws://localhost:8080/baz"
+                                           {:on-message (fn [_ws msg _last?] (deliver message msg))})]
+          (is (= (str @message) "heyo"))
+          (ws/close! websocket))))
 
     (testing "Error occurs when specifying service that does not exist in config file"
       (with-app-with-config


### PR DESCRIPTION
Based on a suggestion in the gniazdo project https://github.com/stalefruits/gniazdo#usage this was updated to use https://github.com/gnarroway/hato instead of stylefruits, which requires it to drop support of jdk8 for testing.