### PR TITLE
(maint) move stylefruits/gniazdo to dev section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       env:
         - FIPS=false
     - # still jdk8
-      script: lein with-profile fips test
+      script: lein with-profile pseudo-dev,fips test
       jdk: openjdk8
       env:
         - FIPS=true
@@ -21,7 +21,7 @@ jobs:
       env:
         - FIPS=false
     - # still jdk11
-      script: lein with-profile fips test
+      script: lein with-profile pseudo-dev,fips test
       jdk: openjdk11
       env:
         - FIPS=true

--- a/project.clj
+++ b/project.clj
@@ -76,22 +76,26 @@
                                        [puppetlabs/trapperkeeper nil :classifier "test"]
                                        [org.clojure/tools.namespace]
                                        [compojure]
-                                       [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
-                                                                             org.eclipse.jetty.websocket/websocket-client
-                                                                             org.eclipse.jetty/jetty-util]]
                                        [ring/ring-core]]
                         :resource-paths ["dev-resources"]
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
 
              :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
+                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
+                                   [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
+                                                                         org.eclipse.jetty.websocket/websocket-client
+                                                                         org.eclipse.jetty/jetty-util]]]}]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
              :provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                         :resource-paths ["dev-resources"]}
-
-             :fips [:defaults ; merge in the dev profile
+             ;; a pseudo dev profile that can be combined with the FIPS profiling for testing only
+             :pseudo-dev {:dependencies [
+                                         [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
+                                                                               org.eclipse.jetty.websocket/websocket-client
+                                                                               org.eclipse.jetty/jetty-util]]]}
+             :fips [:defaults ; merge in the default profile
                     {:dependencies [[org.bouncycastle/bcpkix-fips]
                                     [org.bouncycastle/bc-fips]
                                     [org.bouncycastle/bctls-fips]]


### PR DESCRIPTION
The stylefruits library is only used in tests, and as a result doesn't need to be a full dependency.  This moves it to the dev section so that it is available for tests, but not part of the overall jar.