### PR TITLE
(PE-35872) update jetty to 9.4.51.v20230217 to address CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.4
+* update jetty to 9.4.51.v20230217 to resolve CVE-2023-26048
+
 ## 4.4.1
 * update clj-parent to 5.2.9, which includes the stylefruits/gniazdo dependency.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.48.v20220622")
+(def jetty-version "9.4.51.v20230217")
 
 (defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.4.2-SNAPSHOT"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."


### PR DESCRIPTION
This updates jetty 9 to 9.4.51.v20230217 to address CVE-2023-26048 and CVE-2023-26049