### PR TITLE
(PE-35600) Provide response object to handler when :include-response?

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
@@ -26,6 +26,9 @@
 (def ContextHandlerOptions
   (dissoc (merge jetty9-core/ContextHandlerOptions RouteOption) :server-id))
 
+(def RingHandlerOptions
+  (dissoc (merge jetty9-core/RingHandlerOptions RouteOption) :server-id))
+
 (def ServletHandlerOptions
   (dissoc (merge jetty9-core/ServletHandlerOptions RouteOption) :server-id))
 
@@ -123,7 +126,7 @@
 (schema/defn ^:always-validate add-ring-handler!
   [context webserver-service
    svc :- (schema/protocol tk-services/Service)
-   handler options :- CommonOptions]
+   handler options :- RingHandlerOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-ring-handler    (:add-ring-handler webserver-service)]
     (add-ring-handler handler path opts)))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_core_test.clj
@@ -37,6 +37,7 @@
                                          :body "I am a handler"})
                               "/"
                               true
+                              false
                               false)
       (is (= (count (.getHandlers handlers)) 1)))))
 

--- a/test/clj/puppetlabs/trapperkeeper/testutils/webserver.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/webserver.clj
@@ -27,7 +27,7 @@
   `(let [srv#      (jetty9/start-webserver!
                      (jetty9/initialize-context)
                      (assoc ~config :port 0))
-         _#        (jetty9/add-ring-handler srv# ~app "/" true false)
+         _#        (jetty9/add-ring-handler srv# ~app "/" true false false)
          ~port-var (-> (:server srv#)
                        (.getConnectors)
                        (first)


### PR DESCRIPTION
This is just one way we might solve the problem, and the *pdb-response* binding is just there to support the original investigation, without having to rework pdb's query handlers to accept the additional argument.  Presumably we'll remove that if we decide to pursue these changes.