### PR TITLE
(maint) make service test less sensitive

### DIFF
--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_test.clj
@@ -737,7 +737,7 @@
        ; we have to sleep the thread to avoid a race condition.
        (Thread/sleep 10)
        (let [list (TestListAppender/list)]
-         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200 28" (first list))))))
+         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200 " (first list))))))
 
     (testing "Mapped Diagnostic Context values are available to the access logger"
       (with-test-access-logging


### PR DESCRIPTION
The service test contained a regular expression that matched on the size of the content. The headers that are included in the response depend on the platform and java version that are used to run the tests, so this removes the size part of the regular expression to make the tests less sensitive to environment. The underlying behavior in the test isn't impacted; it still validates that the logging occurred.