### PR TITLE
(maint) udpate clj-parent, github-actions, and project.clj

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -19,14 +19,14 @@ jobs:
         java: [ '8', '11', '17' ]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
       - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@10.2
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
           cli: latest              # Clojure CLI based on tools.deps
           lein: latest                  # Leiningen

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -1,5 +1,8 @@
 name: mend_scan
 on:
+  schedule:
+    # run every day at 4:00am
+    - cron: 0 4 * * *
   workflow_dispatch:
   push:
     branches:
@@ -13,12 +16,12 @@ jobs:
       with:
         service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
     - name: checkout repo content
-      uses: actions/checkout@v2 # checkout the repository content to github runner.
+      uses: actions/checkout@v4 # checkout the repository content to github runner.
       with:
         fetch-depth: 1
     # install java which is required for mend and clojure
     - name: setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 17

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.6.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.6.19"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -79,12 +79,7 @@
                                        [ring/ring-core]]
                         :resource-paths ["dev-resources"]
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
-
-             :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                   [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
-                                                                         org.eclipse.jetty.websocket/websocket-client
-                                                                         org.eclipse.jetty/jetty-util]]]}]
+             :dev [:defaults :pseudo-dev]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
@@ -95,27 +90,26 @@
                                          [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-api
                                                                                org.eclipse.jetty.websocket/websocket-client
                                                                                org.eclipse.jetty/jetty-util]]]}
-             :fips [:defaults ; merge in the default profile
-                    {:dependencies [[org.bouncycastle/bcpkix-fips]
-                                    [org.bouncycastle/bc-fips]
-                                    [org.bouncycastle/bctls-fips]]
-                     :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
-                     ;; this only ensures that we run with the proper profiles
-                     ;; during testing. This JVM opt will be set in the puppet module
-                     ;; that sets up the JVM classpaths during installation.
-                     :jvm-opts ~(let [version (System/getProperty "java.version")
-                                      [major minor _] (clojure.string/split version #"\.")
-                                      unsupported-ex (ex-info "Unsupported major Java version. Expects 11 or 17."
-                                                       {:major major
-                                                        :minor minor})]
-                                  (condp = (java.lang.Integer/parseInt major)
-                                    1 (if (= 8 (java.lang.Integer/parseInt minor))
-                                        ["-Djava.security.properties==dev-resources/jdk8-fips-security"]
-                                        (throw unsupported-ex))
-                                    11 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
-                                    17 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
-                                    (throw unsupported-ex)))}]
-
+             :fips-dependencies {:dependencies [[org.bouncycastle/bcpkix-fips]
+                                                [org.bouncycastle/bc-fips]
+                                                [org.bouncycastle/bctls-fips]]
+                                 :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
+                                 ;; this only ensures that we run with the proper profiles
+                                 ;; during testing. This JVM opt will be set in the puppet module
+                                 ;; that sets up the JVM classpaths during installation.
+                                 :jvm-opts ~(let [version (System/getProperty "java.version")
+                                                  [major minor _] (clojure.string/split version #"\.")
+                                                  unsupported-ex (ex-info "Unsupported major Java version. Expects 11 or 17."
+                                                                   {:major major
+                                                                    :minor minor})]
+                                              (condp = (java.lang.Integer/parseInt major)
+                                                1 (if (= 8 (java.lang.Integer/parseInt minor))
+                                                    ["-Djava.security.properties==dev-resources/jdk8-fips-security"]
+                                                    (throw unsupported-ex))
+                                                11 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
+                                                17 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
+                                                (throw unsupported-ex)))}
+             :fips [:defaults :fips-dependencies] ; merge in the default profile
              :testutils {:source-paths ^:replace ["test/clj"]
                          :java-source-paths ^:replace ["test/java"]}}
 


### PR DESCRIPTION
This updates clj-parent to the latest version in the 5.x branch, updates the github actions to have the latest dependency versions, which was preventing scans from operating correctly, adds a scheduled scan.

Finally it removes the deprecated mixed vector/maps dependencies declarations in project.clj